### PR TITLE
Remove `stdout` writting when using wasm

### DIFF
--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -62,7 +62,7 @@ namespace epiworld {
     #include "virus-bones.hpp"
     #include "virus-distribute-meat.hpp"
     #include "virus-meat.hpp"
-    
+
     #include "tools-bones.hpp"
 
     #include "tool-bones.hpp"
@@ -74,7 +74,7 @@ namespace epiworld {
     #include "entity-meat.hpp"
 
     #include "entities-bones.hpp"
-    
+
     #include "agent-meat-state.hpp"
     #include "agent-bones.hpp"
     #include "agent-meat.hpp"
@@ -88,4 +88,4 @@ namespace epiworld {
 
 }
 
-#endif 
+#endif

--- a/include/epiworld/model-bones.hpp
+++ b/include/epiworld/model-bones.hpp
@@ -13,7 +13,7 @@ class Virus;
 template<typename TSeq>
 class Viruses;
 
-template<typename TSeq> 
+template<typename TSeq>
 class Viruses_const;
 
 template<typename TSeq>
@@ -80,10 +80,10 @@ inline std::function<void(size_t,Model<TSeq>*)> make_save_run(
 
 /**
  * @brief Core class of epiworld.
- * 
+ *
  * The model class provides the wrapper that puts together `Agent`, `Virus`, and
  * `Tools`.
- * 
+ *
  * @tparam TSeq Type of sequence. In principle, users can build models in which
  * virus and human sequence is represented as numeric vectors (if needed.)
  */
@@ -106,7 +106,7 @@ protected:
 
     /**
      * @name Auxiliary variables for AgentsSample<TSeq> iterators
-     * 
+     *
      * @details These variables+objects are used by the AgentsSample<TSeq>
      * class for building efficient iterators over agents. The idea is to
      * reduce the memory allocation, so only during the first call of
@@ -121,11 +121,11 @@ protected:
 
     /**
      * @name Agents features
-     * 
+     *
      * @details Optionally, a model can include an external data source
      * pointing to agents information. The data can then be access through
      * the `Agent::operator()` method.
-     * 
+     *
      */
     ///@{
     double * agents_data = nullptr;
@@ -133,15 +133,15 @@ protected:
     ///@}
 
     bool directed = false;
-    
+
     std::vector< VirusPtr<TSeq> > viruses = {};
     std::vector< ToolPtr<TSeq> > tools = {};
 
-    std::vector< Entity<TSeq> > entities = {}; 
+    std::vector< Entity<TSeq> > entities = {};
     std::vector< Entity<TSeq> > entities_backup = {};
 
     std::mt19937 engine;
-    
+
     std::uniform_real_distribution<> runifd      =
         std::uniform_real_distribution<> (0.0, 1.0);
     std::normal_distribution<>       rnormd      =
@@ -157,20 +157,20 @@ protected:
 
     std::function<void(std::vector<Agent<TSeq>>*,Model<TSeq>*,epiworld_double)> rewire_fun;
     epiworld_double rewire_prop = 0.0;
-        
+
     std::map<std::string, epiworld_double > parameters;
     epiworld_fast_uint ndays = 0;
-    Progress pb;
+	Progress pb;
 
     std::vector< UpdateFun<TSeq> >    state_fun = {};                  ///< Functions to update states
     std::vector< std::string >        states_labels = {};              ///< Labels of the states
-    
+
     /** Function to distribute states. Goes along with the function  */
     std::function<void(Model<TSeq>*)> initial_states_fun = [](Model<TSeq> * /**/)
     -> void {};
 
     epiworld_fast_uint nstates = 0u;
-    
+
     bool verbose     = true;
     int current_date = 0;
 
@@ -182,7 +182,7 @@ protected:
     std::chrono::time_point<std::chrono::steady_clock> time_end;
 
     // std::chrono::milliseconds
-    std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
+    std::chrono::duration<epiworld_double,std::micro> time_elapsed =
         std::chrono::duration<epiworld_double,std::micro>::zero();
     epiworld_fast_uint n_replicates = 0u;
     void chrono_start();
@@ -202,7 +202,7 @@ protected:
 
     /**
      * @brief Construct a new Event object
-     * 
+     *
      * @param agent_ Agent over which the action will be called
      * @param virus_ Virus pointer included in the action
      * @param tool_ Tool pointer included in the action
@@ -227,12 +227,12 @@ protected:
 
     /**
      * @name Tool Mixers
-     * 
+     *
      * These functions combine the effects tools have to deliver
      * a single effect. For example, wearing a mask, been vaccinated,
      * and the immune system combine together to jointly reduce
      * the susceptibility for a given virus.
-     * 
+     *
      */
     MixerFun<TSeq> susceptibility_reduction_mixer = susceptibility_reduction_mixer_default<TSeq>;
     MixerFun<TSeq> transmission_reduction_mixer = transmission_reduction_mixer_default<TSeq>;
@@ -241,14 +241,14 @@ protected:
 
     /**
      * @brief Advanced usage: Makes a copy of data and returns it as undeleted pointer
-     * 
-     * @param copy 
+     *
+     * @param copy
      */
     virtual Model<TSeq> * clone_ptr();
 
 public:
 
-    
+
     std::vector<epiworld_double> array_double_tmp;
     std::vector<Virus<TSeq> * > array_virus_tmp;
     std::vector< int > array_int_tmp;
@@ -266,7 +266,7 @@ public:
      * @details `backup` can be used to restore the entire object
      * after a run. This can be useful if the user wishes to have
      * individuals start with the same network from the beginning.
-     * 
+     *
      */
     ///@{
     void set_backup();
@@ -281,7 +281,7 @@ public:
 
     /**
      * @name Random number generation
-     * 
+     *
      * @param eng Random number generator
      * @param s Seed
      */
@@ -311,9 +311,9 @@ public:
 
     /**
      * @name Add Virus/Tool to the model
-     * 
+     *
      * This is done before the model has been initialized.
-     * 
+     *
      * @param v Virus to be added
      * @param t Tool to be added
      * @param preval Initial prevalence (initial state.) It can be
@@ -331,16 +331,16 @@ public:
 
     /**
      * @brief Associate agents-entities from a file
-     * 
-     * The structure of the file should be two columns separated by 
+     *
+     * The structure of the file should be two columns separated by
      * space. The first column indexing between 0 and nagents-1, and the
      * second column between 0 and nentities - 1.
-     * 
+     *
      * @param fn Path to the file.
      * @param skip How many rows to skip.
      */
     void load_agents_entities_ties(std::string fn, int skip);
-    
+
     /**
      * @brief Associate agents-entities from data
     */
@@ -357,7 +357,7 @@ public:
 
     /**
      * @name Accessing population of the model
-     * 
+     *
      * @param fn std::string Filename of the edgelist file.
      * @param skip int Number of lines to skip in `fn`.
      * @param directed bool Whether the graph is directed or not.
@@ -408,12 +408,12 @@ public:
 
     /**
      * @name Functions to run the model
-     * 
+     *
      * @param seed Seed to be used for Pseudo-RNG.
      * @param ndays Number of days (steps) of the simulation.
      * @param fun In the case of `run_multiple`, a function that is called
      * after each experiment.
-     * 
+     *
      */
     ///@{
     void update_state();
@@ -450,9 +450,9 @@ public:
      * @details This implementation assumes an undirected network,
      * thus if {(i,j), (k,l)} -> {(i,l), (k,j)}, the reciprocal
      * is also true, i.e., {(j,i), (l,k)} -> {(j,k), (l,i)}.
-     * 
+     *
      * @param proportion Proportion of ties to be rewired.
-     * 
+     *
      * @result A rewired version of the network.
      */
     ///@{
@@ -464,7 +464,7 @@ public:
 
     /**
      * @brief Wrapper of `DataBase::write_data`
-     * 
+     *
      * @param fn_virus_info Filename. Information about the virus.
      * @param fn_virus_hist Filename. History of the virus.
      * @param fn_tool_info Filename. Information about the tool.
@@ -488,11 +488,11 @@ public:
 
     /**
      * @name Export the network data in edgelist form
-     * 
+     *
      * @param fn std::string. File name.
      * @param source Integer vector
      * @param target Integer vector
-     * 
+     *
      * @details When passing the source and target, the function will
      * write the edgelist on those.
      */
@@ -511,30 +511,30 @@ public:
 
     /**
      * @brief Reset the model
-     * 
+     *
      * @details Resetting the model will:
      * - clear the database
      * - restore the population (if `set_backup()` was called before)
      * - re-distribute tools
      * - re-distribute viruses
      * - set the date to 0
-     * 
+     *
      */
     virtual void reset();
     const Model<TSeq> & print(bool lite = false) const;
 
     /**
      * @name Manage state (states) in the model
-     * 
+     *
      * @details
-     * 
-     * The functions `get_state` return the current values for the 
+     *
+     * The functions `get_state` return the current values for the
      * states included in the model.
-     * 
+     *
      * @param lab `std::string` Name of the state.
-     * 
+     *
      * @return `add_state*` returns nothing.
-     * @return `get_state_*` returns a vector of pairs with the 
+     * @return `get_state_*` returns a vector of pairs with the
      * states and their labels.
      */
     ///@{
@@ -546,9 +546,9 @@ public:
 
     /**
      * @name Initial states
-     * 
+     *
      * @details These functions are called before the simulation starts.
-     * 
+     *
      * @param proportions_ Vector of proportions for each state.
      * @param queue_ Vector of queue for each state.
      */
@@ -559,7 +559,7 @@ public:
 
     /**
      * @name Setting and accessing parameters from the model
-     * 
+     *
      * @details Tools can incorporate parameters included in the model.
      * Internally, parameters in the tool are stored as pointers to
      * an std::map<> of parameters in the model. Using the `epiworld_fast_uint`
@@ -567,29 +567,29 @@ public:
      * added to the tool. Accessing parameters via the `std::string` method
      * involves searching the parameter directly in the std::map<> member
      * of the model (so it is not recommended.)
-     * 
+     *
      * The `par()` function members are aliases for `get_param()`.
-     * 
+     *
      * In the case of the function `read_params`, users can pass a file
      * listing parameters to be included in the model. Each line in the
      * file should have the following structure:
-     * 
+     *
      * ```
      * [name of parameter 1]: [value in double]
      * [name of parameter 2]: [value in double]
      * ...
      * ```
-     * 
+     *
      * The only condition for parameter names is that these do not include
      * a colon.
-     * 
-     * 
-     * @param initial_val 
+     *
+     *
+     * @param initial_val
      * @param pname Name of the parameter to add or to fetch
      * @param fn Path to the file containing parameters
      * @return The current value of the parameter
      * in the model.
-     * 
+     *
      */
     ///@{
     epiworld_double add_param(epiworld_double initial_val, std::string pname);
@@ -612,7 +612,7 @@ public:
 
     /**
      * @name Set the user data object
-     * 
+     *
      * @param names string vector with the names of the variables.
      */
     ///[@
@@ -624,11 +624,11 @@ public:
 
     /**
      * @brief Set a global action
-     * 
+     *
      * @param fun A function to be called on the prescribed date
      * @param name Name of the action.
      * @param date Integer indicating when the function is called (see details)
-     * 
+     *
      * @details When date is less than zero, then the function is called
      * at the end of every day. Otherwise, the function will be called only
      * at the end of the indicated date.
@@ -656,9 +656,9 @@ public:
     /**
      * @name Queuing system
      * @details When queueing is on, the model will keep track of which agents
-     * are either in risk of exposure or exposed. This then is used at each 
+     * are either in risk of exposure or exposed. This then is used at each
      * step to act only on the aforementioned agents.
-     * 
+     *
      */
     ////@{
     void queuing_on(); ///< Activates the queuing system (default.)
@@ -669,9 +669,9 @@ public:
 
     /**
      * @name Get the susceptibility reduction object
-     * 
-     * @param v 
-     * @return epiworld_double 
+     *
+     * @param v
+     * @return epiworld_double
      */
     ///@{
     void set_susceptibility_reduction_mixer(MixerFun<TSeq> fun);
@@ -687,14 +687,14 @@ public:
 
     /**
      * @brief Set the agents data object
-     * 
+     *
      * @details The data should be an array with the data stored in a
      * column major order, i.e., by column.
-     * 
+     *
      * @param data_ Pointer to the first element of an array of size
      * `size() * ncols_`.
      * @param ncols_ Number of features included in the data.
-     * 
+     *
      */
     void set_agents_data(double * data_, size_t ncols_);
     double * get_agents_data();
@@ -702,8 +702,8 @@ public:
 
     /**
      * @brief Set the name object
-     * 
-     * @param name 
+     *
+     * @param name
      */
     void set_name(std::string name);
     std::string get_name() const;
@@ -713,7 +713,7 @@ public:
 
     /**
      * @brief Executes the stored action
-     * 
+     *
      * @param model_ Model over which it will be executed.
      */
     void events_run();

--- a/include/epiworld/progress.hpp
+++ b/include/epiworld/progress.hpp
@@ -5,18 +5,16 @@
 #define EPIWORLD_PROGRESS_BAR_WIDTH 80
 #endif
 
-/**
- * @brief A simple progress bar
-  */
 class Progress {
-private:
+protected:
     int    width;     ///< Total width size (number of bars)
     int    n;         ///< Total number of iterations
     epiworld_double step_size; ///< Size of the step
     int last_loc;     ///< Last location of the bar
     int cur_loc;      ///< Last location of the bar
     int i;            ///< Current iteration step
-    
+    bool done;        ///< If the progress bar has finished.
+
 public:
     Progress() {};
     Progress(int n_, int width_);
@@ -26,6 +24,9 @@ public:
     void next();
     void end();
 
+    int get_total();
+    int get_current();
+    bool is_done();
 };
 
 inline Progress::Progress(int n_, int width_) {
@@ -46,8 +47,40 @@ inline Progress::Progress(int n_, int width_) {
 
 }
 
+#ifdef __wasm__
 inline void Progress::start()
 {
+
+	done = false;
+
+}
+
+inline void Progress::next()
+{
+
+	if (i == 0)
+        start();
+
+    cur_loc = std::floor((++i) * step_size);
+
+    if (i >= n)
+        end();
+
+    last_loc = cur_loc;
+
+}
+
+inline void Progress::stop()
+{
+
+	done = true;
+
+}
+#else
+inline void Progress::start()
+{
+
+	done = false;
 
     #ifndef EPI_DEBUG
     for (int j = 0; j < (width); ++j)
@@ -67,7 +100,7 @@ inline void Progress::next() {
 
     #ifndef EPI_DEBUG
     for (int j = 0; j < (cur_loc - last_loc); ++j)
-    { 
+    {
         printf_epiworld("|");
     }
     #endif
@@ -81,9 +114,32 @@ inline void Progress::next() {
 
 inline void Progress::end() {
 
+	done = true;
+
     #ifndef EPI_DEBUG
     printf_epiworld(" done.\n");
     #endif
+
+}
+#endif /* __wasm__ */
+
+inline int Progress::get_total() {
+
+	return n;
+
+}
+
+inline int Progress::get_current()
+{
+
+	return i;
+
+}
+
+inline bool Progress::is_done()
+{
+
+	return done;
 
 }
 


### PR DESCRIPTION
I tried to mirror the code style I've seen elsewhere in Epiworld, but if it's incorrect let know and I'll be happy to fix. Required by [UofUEpiBio/epiworldweb](https://github.com/UofUEpiBio/epiworldweb).

In a better world, we would use an interface and allow the backend to be switched by the caller, but that would change the API which I don't think is wanted.