### PR TITLE
Moving engine to be shared pointer instead of dumb pointer

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,19 +1,16 @@
 {
-    "configurations": [
-        {
-            "name": "osx",
-            "includePath": [
-                "${workspaceFolder}/**",
-                "/usr/local/include",
-                "include/epiworld"
-            ],
-            "defines": [],
-            "compilerPath": "/usr/bin/g++",
-            "cStandard": "gnu17",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "${default}"
-        }
-    ],
-    "version": 4
+  "configurations": [
+    {
+      "name": "macos-clang-arm64",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "defines": [],
+      "compilerPath": "/usr/bin/clang",
+      "cStandard": "${default}",
+      "cppStandard": "${default}",
+      "intelliSenseMode": "macos-clang-arm64"
+    }
+  ],
+  "version": 4
 }
-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,5 +79,6 @@
       "language": "quarto",
       "scheme": "file"
     }
-  ]
+  ],
+  "C_Cpp_Runner.msvcBatchPath": ""
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,5 +80,61 @@
       "scheme": "file"
     }
   ],
-  "C_Cpp_Runner.msvcBatchPath": ""
+  "C_Cpp_Runner.msvcBatchPath": "",
+  "C_Cpp_Runner.cCompilerPath": "clang",
+  "C_Cpp_Runner.cppCompilerPath": "clang++",
+  "C_Cpp_Runner.debuggerPath": "lldb",
+  "C_Cpp_Runner.cStandard": "",
+  "C_Cpp_Runner.cppStandard": "",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false
 }

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -6485,7 +6485,7 @@ public:
      * @param s Seed
      */
     ///@{
-    void set_rand_engine(std::mt19937 & eng);
+    void set_rand_engine(std::shared_ptr< std::mt19937 > & eng);
     std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(size_t s);
     void set_rand_norm(epiworld_double mean, epiworld_double sd);
@@ -17031,7 +17031,7 @@ inline ModelSURV<TSeq>::ModelSURV(
 
         // How many will we find
         std::binomial_distribution<> bdist(m->size(), m->par("Surveilance prob."));
-        int nsampled = bdist(m->get_rand_endgine());
+        int nsampled = bdist(*m->get_rand_endgine());
 
         int to_go = nsampled + 1;
 

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 0
+#define EPIWORLD_VERSION_PATCH 1
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;
@@ -1178,7 +1178,7 @@ class LFMCMC {
 private:
 
     // Random number sampling
-    std::mt19937 * engine = nullptr;
+    std::shared_ptr< std::mt19937 > engine = nullptr;
     
     std::shared_ptr< std::uniform_real_distribution<> > runifd =
         std::make_shared< std::uniform_real_distribution<> >(0.0, 1.0);
@@ -1190,7 +1190,7 @@ private:
         std::make_shared< std::gamma_distribution<> >();
 
     // Process data
-    TData * observed_data;
+    TData observed_data;
     
     // Information about the size of the problem
     size_t n_samples;
@@ -1253,10 +1253,10 @@ public:
         );
 
     LFMCMC() {};
-    LFMCMC(TData & observed_data_) : observed_data(&observed_data_) {};
+    LFMCMC(const TData & observed_data_) : observed_data(observed_data_) {};
     ~LFMCMC() {};
 
-    void set_observed_data(TData & observed_data_) {observed_data = &observed_data_;};
+    void set_observed_data(const TData & observed_data_) {observed_data = observed_data_;};
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
@@ -1268,8 +1268,8 @@ public:
      * @param eng 
      */
     ///@{
-    void set_rand_engine(std::mt19937 & eng);
-    std::mt19937 & get_rand_endgine();
+    void set_rand_engine(std::shared_ptr< std::mt19937 > & eng);
+    std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(epiworld_fast_uint s);
     void set_rand_gamma(epiworld_double alpha, epiworld_double beta);
     epiworld_double runif();
@@ -1455,7 +1455,7 @@ class LFMCMC {
 private:
 
     // Random number sampling
-    std::mt19937 * engine = nullptr;
+    std::shared_ptr< std::mt19937 > engine = nullptr;
     
     std::shared_ptr< std::uniform_real_distribution<> > runifd =
         std::make_shared< std::uniform_real_distribution<> >(0.0, 1.0);
@@ -1467,7 +1467,7 @@ private:
         std::make_shared< std::gamma_distribution<> >();
 
     // Process data
-    TData * observed_data;
+    TData observed_data;
     
     // Information about the size of the problem
     size_t n_samples;
@@ -1530,10 +1530,10 @@ public:
         );
 
     LFMCMC() {};
-    LFMCMC(TData & observed_data_) : observed_data(&observed_data_) {};
+    LFMCMC(const TData & observed_data_) : observed_data(observed_data_) {};
     ~LFMCMC() {};
 
-    void set_observed_data(TData & observed_data_) {observed_data = &observed_data_;};
+    void set_observed_data(const TData & observed_data_) {observed_data = observed_data_;};
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
@@ -1545,8 +1545,8 @@ public:
      * @param eng 
      */
     ///@{
-    void set_rand_engine(std::mt19937 & eng);
-    std::mt19937 & get_rand_endgine();
+    void set_rand_engine(std::shared_ptr< std::mt19937 > & eng);
+    std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(epiworld_fast_uint s);
     void set_rand_gamma(epiworld_double alpha, epiworld_double beta);
     epiworld_double runif();
@@ -1819,7 +1819,7 @@ inline void LFMCMC<TData>::run(
     params_now  = params_init;
 
     // Computing the baseline sufficient statistics
-    summary_fun(observed_stats, *observed_data, this);
+    summary_fun(observed_stats, observed_data, this);
     n_statistics = observed_stats.size();
 
     // Reserving size
@@ -1969,9 +1969,9 @@ inline void LFMCMC<TData>::seed(epiworld_fast_uint s) {
 }
 
 template<typename TData>
-inline void LFMCMC<TData>::set_rand_engine(std::mt19937 & eng)
+inline void LFMCMC<TData>::set_rand_engine(std::shared_ptr< std::mt19937 > & eng)
 {
-    engine = &eng;
+    engine = eng;
 }
 
 template<typename TData>
@@ -1981,9 +1981,9 @@ inline void LFMCMC<TData>::set_rand_gamma(epiworld_double alpha, epiworld_double
 }
 
 template<typename TData>
-inline std::mt19937 & LFMCMC<TData>::get_rand_endgine()
+inline std::shared_ptr< std::mt19937 > & LFMCMC<TData>::get_rand_endgine()
 {
-    return *engine;
+    return engine;
 }
 
 // Step 1: Simulate data
@@ -6339,7 +6339,7 @@ protected:
     std::vector< Entity<TSeq> > entities = {}; 
     std::vector< Entity<TSeq> > entities_backup = {};
 
-    std::mt19937 engine;
+    std::shared_ptr< std::mt19937 > engine = std::make_shared< std::mt19937 >();
     
     std::uniform_real_distribution<> runifd      =
         std::uniform_real_distribution<> (0.0, 1.0);
@@ -6486,7 +6486,7 @@ public:
      */
     ///@{
     void set_rand_engine(std::mt19937 & eng);
-    std::mt19937 & get_rand_endgine();
+    std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(size_t s);
     void set_rand_norm(epiworld_double mean, epiworld_double sd);
     void set_rand_unif(epiworld_double a, epiworld_double b);
@@ -7615,12 +7615,6 @@ inline void Model<TSeq>::agents_empty_graph(
 
 }
 
-// template<typename TSeq>
-// inline void Model<TSeq>::set_rand_engine(std::mt19937 & eng)
-// {
-//     engine = std::make_shared< std::mt19937 >(eng);
-// }
-
 template<typename TSeq>
 inline void Model<TSeq>::set_rand_gamma(epiworld_double alpha, epiworld_double beta)
 {
@@ -7761,7 +7755,7 @@ inline void Model<TSeq>::set_backup()
 // }
 
 template<typename TSeq>
-inline std::mt19937 & Model<TSeq>::get_rand_endgine()
+inline std::shared_ptr< std::mt19937 > & Model<TSeq>::get_rand_endgine()
 {
     return engine;
 }
@@ -7769,86 +7763,86 @@ inline std::mt19937 & Model<TSeq>::get_rand_endgine()
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::runif() {
     // CHECK_INIT()
-    return runifd(engine);
+    return runifd(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::runif(epiworld_double a, epiworld_double b) {
     // CHECK_INIT()
-    return runifd(engine) * (b - a) + a;
+    return runifd(*engine) * (b - a) + a;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rnorm() {
     // CHECK_INIT()
-    return rnormd(engine);
+    return rnormd(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rnorm(epiworld_double mean, epiworld_double sd) {
     // CHECK_INIT()
-    return rnormd(engine) * sd + mean;
+    return rnormd(*engine) * sd + mean;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rgamma() {
-    return rgammad(engine);
+    return rgammad(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rgamma(epiworld_double alpha, epiworld_double beta) {
     auto old_param = rgammad.param();
     rgammad.param(std::gamma_distribution<>::param_type(alpha, beta));
-    epiworld_double ans = rgammad(engine);
+    epiworld_double ans = rgammad(*engine);
     rgammad.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rexp() {
-    return rexpd(engine);
+    return rexpd(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rexp(epiworld_double lambda) {
     auto old_param = rexpd.param();
     rexpd.param(std::exponential_distribution<>::param_type(lambda));
-    epiworld_double ans = rexpd(engine);
+    epiworld_double ans = rexpd(*engine);
     rexpd.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rlognormal() {
-    return rlognormald(engine);
+    return rlognormald(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rlognormal(epiworld_double mean, epiworld_double shape) {
     auto old_param = rlognormald.param();
     rlognormald.param(std::lognormal_distribution<>::param_type(mean, shape));
-    epiworld_double ans = rlognormald(engine);
+    epiworld_double ans = rlognormald(*engine);
     rlognormald.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline int Model<TSeq>::rbinom() {
-    return rbinomd(engine);
+    return rbinomd(*engine);
 }
 
 template<typename TSeq>
 inline int Model<TSeq>::rbinom(int n, epiworld_double p) {
     auto old_param = rbinomd.param();
     rbinomd.param(std::binomial_distribution<>::param_type(n, p));
-    epiworld_double ans = rbinomd(engine);
+    epiworld_double ans = rbinomd(*engine);
     rbinomd.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline void Model<TSeq>::seed(size_t s) {
-    this->engine.seed(s);
+    this->engine->seed(s);
 }
 
 template<typename TSeq>
@@ -8238,7 +8232,7 @@ inline Model<TSeq> & Model<TSeq>::run(
     this->ndays = ndays;
 
     if (seed >= 0)
-        engine.seed(seed);
+        engine->seed(seed);
 
     array_double_tmp.resize(std::max(
         size(),

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 0
+#define EPIWORLD_VERSION_PATCH 1
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -116,7 +116,7 @@ class LFMCMC {
 private:
 
     // Random number sampling
-    std::mt19937 * engine = nullptr;
+    std::shared_ptr< std::mt19937 > engine = nullptr;
     
     std::shared_ptr< std::uniform_real_distribution<> > runifd =
         std::make_shared< std::uniform_real_distribution<> >(0.0, 1.0);
@@ -128,7 +128,7 @@ private:
         std::make_shared< std::gamma_distribution<> >();
 
     // Process data
-    TData * observed_data;
+    TData observed_data;
     
     // Information about the size of the problem
     size_t n_samples;
@@ -191,10 +191,10 @@ public:
         );
 
     LFMCMC() {};
-    LFMCMC(TData & observed_data_) : observed_data(&observed_data_) {};
+    LFMCMC(const TData & observed_data_) : observed_data(observed_data_) {};
     ~LFMCMC() {};
 
-    void set_observed_data(TData & observed_data_) {observed_data = &observed_data_;};
+    void set_observed_data(const TData & observed_data_) {observed_data = observed_data_;};
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
@@ -206,8 +206,8 @@ public:
      * @param eng 
      */
     ///@{
-    void set_rand_engine(std::mt19937 & eng);
-    std::mt19937 & get_rand_endgine();
+    void set_rand_engine(std::shared_ptr< std::mt19937 > & eng);
+    std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(epiworld_fast_uint s);
     void set_rand_gamma(epiworld_double alpha, epiworld_double beta);
     epiworld_double runif();

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -228,7 +228,7 @@ inline void LFMCMC<TData>::run(
     params_now  = params_init;
 
     // Computing the baseline sufficient statistics
-    summary_fun(observed_stats, *observed_data, this);
+    summary_fun(observed_stats, observed_data, this);
     n_statistics = observed_stats.size();
 
     // Reserving size
@@ -378,9 +378,9 @@ inline void LFMCMC<TData>::seed(epiworld_fast_uint s) {
 }
 
 template<typename TData>
-inline void LFMCMC<TData>::set_rand_engine(std::mt19937 & eng)
+inline void LFMCMC<TData>::set_rand_engine(std::shared_ptr< std::mt19937 > & eng)
 {
-    engine = &eng;
+    engine = eng;
 }
 
 template<typename TData>
@@ -390,9 +390,9 @@ inline void LFMCMC<TData>::set_rand_gamma(epiworld_double alpha, epiworld_double
 }
 
 template<typename TData>
-inline std::mt19937 & LFMCMC<TData>::get_rand_endgine()
+inline std::shared_ptr< std::mt19937 > & LFMCMC<TData>::get_rand_endgine()
 {
-    return *engine;
+    return engine;
 }
 
 // Step 1: Simulate data

--- a/include/epiworld/model-bones.hpp
+++ b/include/epiworld/model-bones.hpp
@@ -140,7 +140,7 @@ protected:
     std::vector< Entity<TSeq> > entities = {}; 
     std::vector< Entity<TSeq> > entities_backup = {};
 
-    std::mt19937 engine;
+    std::shared_ptr< std::mt19937 > engine = std::make_shared< std::mt19937 >();
     
     std::uniform_real_distribution<> runifd      =
         std::uniform_real_distribution<> (0.0, 1.0);
@@ -287,7 +287,7 @@ public:
      */
     ///@{
     void set_rand_engine(std::mt19937 & eng);
-    std::mt19937 & get_rand_endgine();
+    std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(size_t s);
     void set_rand_norm(epiworld_double mean, epiworld_double sd);
     void set_rand_unif(epiworld_double a, epiworld_double b);

--- a/include/epiworld/model-bones.hpp
+++ b/include/epiworld/model-bones.hpp
@@ -286,7 +286,7 @@ public:
      * @param s Seed
      */
     ///@{
-    void set_rand_engine(std::mt19937 & eng);
+    void set_rand_engine(std::shared_ptr< std::mt19937 > & eng);
     std::shared_ptr< std::mt19937 > & get_rand_endgine();
     void seed(size_t s);
     void set_rand_norm(epiworld_double mean, epiworld_double sd);

--- a/include/epiworld/model-meat.hpp
+++ b/include/epiworld/model-meat.hpp
@@ -674,12 +674,6 @@ inline void Model<TSeq>::agents_empty_graph(
 
 }
 
-// template<typename TSeq>
-// inline void Model<TSeq>::set_rand_engine(std::mt19937 & eng)
-// {
-//     engine = std::make_shared< std::mt19937 >(eng);
-// }
-
 template<typename TSeq>
 inline void Model<TSeq>::set_rand_gamma(epiworld_double alpha, epiworld_double beta)
 {
@@ -820,7 +814,7 @@ inline void Model<TSeq>::set_backup()
 // }
 
 template<typename TSeq>
-inline std::mt19937 & Model<TSeq>::get_rand_endgine()
+inline std::shared_ptr< std::mt19937 > & Model<TSeq>::get_rand_endgine()
 {
     return engine;
 }
@@ -828,86 +822,86 @@ inline std::mt19937 & Model<TSeq>::get_rand_endgine()
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::runif() {
     // CHECK_INIT()
-    return runifd(engine);
+    return runifd(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::runif(epiworld_double a, epiworld_double b) {
     // CHECK_INIT()
-    return runifd(engine) * (b - a) + a;
+    return runifd(*engine) * (b - a) + a;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rnorm() {
     // CHECK_INIT()
-    return rnormd(engine);
+    return rnormd(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rnorm(epiworld_double mean, epiworld_double sd) {
     // CHECK_INIT()
-    return rnormd(engine) * sd + mean;
+    return rnormd(*engine) * sd + mean;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rgamma() {
-    return rgammad(engine);
+    return rgammad(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rgamma(epiworld_double alpha, epiworld_double beta) {
     auto old_param = rgammad.param();
     rgammad.param(std::gamma_distribution<>::param_type(alpha, beta));
-    epiworld_double ans = rgammad(engine);
+    epiworld_double ans = rgammad(*engine);
     rgammad.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rexp() {
-    return rexpd(engine);
+    return rexpd(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rexp(epiworld_double lambda) {
     auto old_param = rexpd.param();
     rexpd.param(std::exponential_distribution<>::param_type(lambda));
-    epiworld_double ans = rexpd(engine);
+    epiworld_double ans = rexpd(*engine);
     rexpd.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rlognormal() {
-    return rlognormald(engine);
+    return rlognormald(*engine);
 }
 
 template<typename TSeq>
 inline epiworld_double Model<TSeq>::rlognormal(epiworld_double mean, epiworld_double shape) {
     auto old_param = rlognormald.param();
     rlognormald.param(std::lognormal_distribution<>::param_type(mean, shape));
-    epiworld_double ans = rlognormald(engine);
+    epiworld_double ans = rlognormald(*engine);
     rlognormald.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline int Model<TSeq>::rbinom() {
-    return rbinomd(engine);
+    return rbinomd(*engine);
 }
 
 template<typename TSeq>
 inline int Model<TSeq>::rbinom(int n, epiworld_double p) {
     auto old_param = rbinomd.param();
     rbinomd.param(std::binomial_distribution<>::param_type(n, p));
-    epiworld_double ans = rbinomd(engine);
+    epiworld_double ans = rbinomd(*engine);
     rbinomd.param(old_param);
     return ans;
 }
 
 template<typename TSeq>
 inline void Model<TSeq>::seed(size_t s) {
-    this->engine.seed(s);
+    this->engine->seed(s);
 }
 
 template<typename TSeq>
@@ -1297,7 +1291,7 @@ inline Model<TSeq> & Model<TSeq>::run(
     this->ndays = ndays;
 
     if (seed >= 0)
-        engine.seed(seed);
+        engine->seed(seed);
 
     array_double_tmp.resize(std::max(
         size(),

--- a/include/epiworld/models/surveillance.hpp
+++ b/include/epiworld/models/surveillance.hpp
@@ -227,7 +227,7 @@ inline ModelSURV<TSeq>::ModelSURV(
 
         // How many will we find
         std::binomial_distribution<> bdist(m->size(), m->par("Surveilance prob."));
-        int nsampled = bdist(m->get_rand_endgine());
+        int nsampled = bdist(*m->get_rand_endgine());
 
         int to_go = nsampled + 1;
 

--- a/include/epiworld/random_graph.hpp
+++ b/include/epiworld/random_graph.hpp
@@ -14,7 +14,7 @@ public:
     RandGraph(int N_) : N(N_) {};
 
     void init(int s);
-    void set_rand_engine(std::mt19937 & e);
+    void set_rand_engine(std::shared_ptr< std::mt19937 > & e);
     epiworld_double runif();
 
 };
@@ -35,10 +35,10 @@ inline void RandGraph::init(int s) {
 
 }
 
-inline void RandGraph::set_rand_engine(std::mt19937 & e)
+inline void RandGraph::set_rand_engine(std::shared_ptr< std::mt19937 > & e)
 {
 
-    engine = std::make_shared< std::mt19937 >(e);
+    engine = e;
 
 }
 

--- a/tests/00-lfmcmc.cpp
+++ b/tests/00-lfmcmc.cpp
@@ -44,13 +44,13 @@ void summary_fun(vec_double & res, const vec_double & p, LFMCMC<vec_double> * m)
 
 EPIWORLD_TEST_CASE("LFMCMC", "[Basic example]") {
 
-    std::mt19937 rand;
-    rand.seed(91231);
+    auto rand = std::make_shared<std::mt19937>();
+    rand->seed(91231);
     std::normal_distribution<epiworld_double> rnorm(5, 1.5);
 
     vec_double obsdata;
     for (size_t i = 0u; i < 50000; ++i)
-        obsdata.push_back(rnorm(rand));
+        obsdata.push_back(rnorm(*rand));
 
     LFMCMC< vec_double > model(obsdata);
     model.set_rand_engine(rand);


### PR DESCRIPTION
This pull request includes several changes to improve memory management and consistency in the codebase by switching from raw pointers to `std::shared_ptr` for random number engines and data structures. The changes also include updates to the related methods to accommodate this new approach.

Memory Management Improvements:

* [`include/epiworld/math/lfmcmc/lfmcmc-bones.hpp`](diffhunk://#diff-c6fcdc4ba156323be017e575a8a2708311fd860d98365fde2245f4d041a419ccL119-R119): Replaced raw pointers with `std::shared_ptr` for `std::mt19937` engine and `TData` observed data. Updated constructors and methods accordingly. [[1]](diffhunk://#diff-c6fcdc4ba156323be017e575a8a2708311fd860d98365fde2245f4d041a419ccL119-R119) [[2]](diffhunk://#diff-c6fcdc4ba156323be017e575a8a2708311fd860d98365fde2245f4d041a419ccL131-R131) [[3]](diffhunk://#diff-c6fcdc4ba156323be017e575a8a2708311fd860d98365fde2245f4d041a419ccL194-R197) [[4]](diffhunk://#diff-c6fcdc4ba156323be017e575a8a2708311fd860d98365fde2245f4d041a419ccL209-R210)
* [`include/epiworld/math/lfmcmc/lfmcmc-meat.hpp`](diffhunk://#diff-8d8abf4db02f270dbef50fd663b56c58e3380f3f1c2c728b40338c75a39c826bL231-R231): Updated methods to use `std::shared_ptr` for the `std::mt19937` engine. [[1]](diffhunk://#diff-8d8abf4db02f270dbef50fd663b56c58e3380f3f1c2c728b40338c75a39c826bL231-R231) [[2]](diffhunk://#diff-8d8abf4db02f270dbef50fd663b56c58e3380f3f1c2c728b40338c75a39c826bL381-R383) [[3]](diffhunk://#diff-8d8abf4db02f270dbef50fd663b56c58e3380f3f1c2c728b40338c75a39c826bL393-R395)
* [`include/epiworld/model-bones.hpp`](diffhunk://#diff-a450cd7222a075334d9031fd8339c9f1c43ccee73e3602434b83796ad056347cL143-R143): Changed the `std::mt19937` engine to `std::shared_ptr` and updated relevant methods. [[1]](diffhunk://#diff-a450cd7222a075334d9031fd8339c9f1c43ccee73e3602434b83796ad056347cL143-R143) [[2]](diffhunk://#diff-a450cd7222a075334d9031fd8339c9f1c43ccee73e3602434b83796ad056347cL290-R290)
* [`include/epiworld/model-meat.hpp`](diffhunk://#diff-501cd8978f05e81715765fdf2df0552b9f9fbaf8d22a9f4051444bd201b690b6L677-L682): Modified methods to use `std::shared_ptr` for the `std::mt19937` engine and updated random number generation functions to dereference the shared pointer. [[1]](diffhunk://#diff-501cd8978f05e81715765fdf2df0552b9f9fbaf8d22a9f4051444bd201b690b6L677-L682) [[2]](diffhunk://#diff-501cd8978f05e81715765fdf2df0552b9f9fbaf8d22a9f4051444bd201b690b6L823-R904) [[3]](diffhunk://#diff-501cd8978f05e81715765fdf2df0552b9f9fbaf8d22a9f4051444bd201b690b6L1300-R1294)
* [`include/epiworld/random_graph.hpp`](diffhunk://#diff-69b83ea399c51fd0f4cde84beea6886ff086458205b055f673598d8006152ef7L17-R17): Updated the `set_rand_engine` method to accept a `std::shared_ptr` for the `std::mt19937` engine. [[1]](diffhunk://#diff-69b83ea399c51fd0f4cde84beea6886ff086458205b055f673598d8006152ef7L17-R17) [[2]](diffhunk://#diff-69b83ea399c51fd0f4cde84beea6886ff086458205b055f673598d8006152ef7L38-R41)
* [`tests/00-lfmcmc.cpp`](diffhunk://#diff-7e8cf366d246f3834113b6766ade9f82975a40981eb80a713458125a9a83ffa6L47-R53): Changed the random engine to use `std::shared_ptr` and updated the seed and usage accordingly.

Additionally, a small change was made to the `.vscode/settings.json` file to add a new configuration setting.

Configuration Update:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L82-R83): Added `C_Cpp_Runner.msvcBatchPath` setting.