### PR TITLE
Adding check on epiworldR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   test-epiworld-r:
     runs-on: ubuntu-latest
-    container: rocker/r-base:latest
+    container: rocker/r2u:latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/checkout@v4
+        with:
+          repository: UofUEpiBio/epiworldR
+          path: ./r-pkg
+
       - name: Getting epiworldR
         run: |
-          git clone --depth=1 https://github.com/UofUEpiBio/epiworldR.git r-pkg
           rsync -avz include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
           R CMD INSTALL epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,17 @@ jobs:
           cd tests
           make main.o
           ./main.o
+
+  test-epiworld-r:
+    runs-on: ubuntu-latest
+    container: rocker/r-base:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Getting epiworldR
+        run: |
+          git clone --depth=1 https://github.com/UofUEpiBio/epiworldR.git r-pkg
+          rsync -avz include/epiworld/ r-pkg/inst/include/epiworld/
+          R CMD build r-pkg
+          R CMD INSTALL epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Getting epiworldR
         run: |
           install2.r knitr rmarkdown tinytest netplot igraph data.table
+          apt-get update && apt-get install -y --no-install-recommends pandoc 
           cp -r include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
           R CMD INSTALL epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
           apt-get update && apt-get install -y --no-install-recommends pandoc 
           cp -r include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
-          R CMD INSTALL epiworldR_*.tar.gz
+          R CMD check epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,4 @@ jobs:
             pandoc valgrind
           cp -r include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
-          R CMD check --no-manual epiworldR_*.tar.gz
+          R CMD check --no-manual --use-valgrind epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,25 @@ jobs:
           apt-get update && apt-get install -y --no-install-recommends pandoc 
           cp -r include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
-          R CMD check epiworldR_*.tar.gz
+          R CMD check --no-manual epiworldR_*.tar.gz
+
+  test-epiworld-r-valgrind:
+    runs-on: ubuntu-latest
+    container: rocker/r2u:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: UofUEpiBio/epiworldR
+          path: ./r-pkg
+
+      - name: Getting epiworldR
+        run: |
+          install2.r knitr rmarkdown tinytest netplot igraph data.table
+          apt-get update && apt-get install -y --no-install-recommends \
+            pandoc valgrind
+          cp -r include/epiworld/ r-pkg/inst/include/epiworld/
+          R CMD build r-pkg
+          R CMD check --no-manual epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,6 @@ jobs:
 
       - name: Getting epiworldR
         run: |
-          rsync -avz include/epiworld/ r-pkg/inst/include/epiworld/
+          cp -r include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
           R CMD INSTALL epiworldR_*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@
 
 name: Tests
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   test-macos:
@@ -67,6 +70,7 @@ jobs:
 
       - name: Getting epiworldR
         run: |
+          install2.r knitr rmarkdown tinytest netplot igraph data.table
           cp -r include/epiworld/ r-pkg/inst/include/epiworld/
           R CMD build r-pkg
           R CMD INSTALL epiworldR_*.tar.gz


### PR DESCRIPTION
This pull request includes significant updates to the continuous integration (CI) workflow configuration in the `.github/workflows/ci.yml` file. The changes primarily focus on specifying branch triggers for CI actions and adding new jobs to test the `epiworldR` package.

Key changes include:

### CI Workflow Configuration:

* Updated the `on` section to trigger CI actions only on pushes to the `master` branch and on pull requests.

### New Jobs for Testing `epiworldR`:

* Added a new job `test-epiworld-r` to run tests for the `epiworldR` package using the `rocker/r2u:latest` container. This job installs necessary R packages and dependencies, builds the package, and runs checks.
* Added another job `test-epiworld-r-valgrind` similar to `test-epiworld-r`, but with additional steps to install `valgrind` and run the package checks using `valgrind` for memory analysis.