### PR TITLE
Multiple patches to lfmcmc

### DIFF
--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 1
+#define EPIWORLD_VERSION_PATCH 2
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;
@@ -1249,7 +1249,8 @@ public:
     void run(
         std::vector< epiworld_double > param_init,
         size_t n_samples_,
-        epiworld_double epsilon_
+        epiworld_double epsilon_,
+        int seed = -1
         );
 
     LFMCMC() {};
@@ -1526,7 +1527,8 @@ public:
     void run(
         std::vector< epiworld_double > param_init,
         size_t n_samples_,
-        epiworld_double epsilon_
+        epiworld_double epsilon_,
+        int seed = -1
         );
 
     LFMCMC() {};
@@ -1796,7 +1798,8 @@ template<typename TData>
 inline void LFMCMC<TData>::run(
     std::vector< epiworld_double > params_init_,
     size_t n_samples_,
-    epiworld_double epsilon_
+    epiworld_double epsilon_,
+    int seed
     )
 {
 
@@ -1808,6 +1811,9 @@ inline void LFMCMC<TData>::run(
     epsilon      = epsilon_;
     params_init  = params_init_;
     n_parameters = params_init_.size();
+
+    if (seed >= 0)
+        this->seed(seed);
 
     params_now.resize(n_parameters);
     params_prev.resize(n_parameters);

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 3
+#define EPIWORLD_VERSION_PATCH 4
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -2092,15 +2092,18 @@ template<typename TData>
 inline void LFMCMC<TData>::print(size_t burnin) const
 {
 
+    // For each statistic or parameter in the model, we print three values: 
+    // - mean, the 2.5% quantile, and the 97.5% quantile
     std::vector< epiworld_double > summ_params(n_parameters * 3, 0.0);
     std::vector< epiworld_double > summ_stats(n_statistics * 3, 0.0);
 
+    // Compute the number of samples to use based on burnin rate
     size_t n_samples_print = n_samples;
     if (burnin > 0)
     {
         if (burnin >= n_samples)
             throw std::length_error(
-                "The burnin is greater than the number of samples."
+                "The burnin is greater than or equal to the number of samples."
                 );
 
         n_samples_print = n_samples - burnin;
@@ -2111,6 +2114,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         n_samples_print
         );
 
+    // Compute parameter summary values
     for (size_t k = 0u; k < n_parameters; ++k)
     {
 
@@ -2118,8 +2122,8 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > par_i(n_samples_print);
         for (size_t i = burnin; i < n_samples; ++i)
         {
-            par_i[i] = accepted_params[i * n_parameters + k];
-            summ_params[k * 3] += par_i[i]/n_samples_dbl;
+            par_i[i-burnin] = accepted_params[i * n_parameters + k];
+            summ_params[k * 3] += par_i[i-burnin]/n_samples_dbl;
         }
 
         // Computing the 95% Credible interval
@@ -2132,6 +2136,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     }
 
+    // Compute statistics summary values
     for (size_t k = 0u; k < n_statistics; ++k)
     {
 
@@ -2139,13 +2144,12 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > stat_k(n_samples_print);
         for (size_t i = burnin; i < n_samples; ++i)
         {
-            stat_k[i] = accepted_stats[i * n_statistics + k];
-            summ_stats[k * 3] += stat_k[i]/n_samples_dbl;
+            stat_k[i-burnin] = accepted_stats[i * n_statistics + k];
+            summ_stats[k * 3] += stat_k[i-burnin]/n_samples_dbl;
         }
 
         // Computing the 95% Credible interval
         std::sort(stat_k.begin(), stat_k.end());
-
         summ_stats[k * 3 + 1u] = 
             stat_k[std::floor(.025 * n_samples_dbl)];
         summ_stats[k * 3 + 2u] = 

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -595,7 +595,7 @@ inline bool IN(const Ta & a, const std::vector< Ta > & b) noexcept
  * @return int If -1 then it means that none got sampled, otherwise the index
  * of the entry that got drawn.
  */
-template<typename TSeq, typename TDbl>
+template<typename TSeq = EPI_DEFAULT_TSEQ, typename TDbl = epiworld_double >
 inline int roulette(
     const std::vector< TDbl > & probs,
     Model<TSeq> * m
@@ -7661,7 +7661,7 @@ template<typename TSeq>
 inline epiworld_double & Model<TSeq>::operator()(std::string pname) {
 
     if (parameters.find(pname) == parameters.end())
-        throw std::range_error("The parameter "+ pname + "is not in the model.");
+        throw std::range_error("The parameter '"+ pname + "' is not in the model.");
 
     return parameters[pname];
 
@@ -13078,7 +13078,7 @@ namespace sampler {
  * @return Virus<TSeq>* of the selected virus. If none selected (or none
  * available,) returns a nullptr;
  */
-template<typename TSeq>
+template<typename TSeq = EPI_DEFAULT_TSEQ>
 inline std::function<void(Agent<TSeq>*,Model<TSeq>*)> make_update_susceptible(
     std::vector< epiworld_fast_uint > exclude = {}
     )
@@ -13237,7 +13237,7 @@ inline std::function<void(Agent<TSeq>*,Model<TSeq>*)> make_update_susceptible(
  * @return Virus<TSeq>* of the selected virus. If none selected (or none
  * available,) returns a nullptr;
  */
-template<typename TSeq = int>
+template<typename TSeq = EPI_DEFAULT_TSEQ>
 inline std::function<Virus<TSeq>*(Agent<TSeq>*,Model<TSeq>*)> make_sample_virus_neighbors(
     std::vector< epiworld_fast_uint > exclude = {}
 )
@@ -13405,7 +13405,7 @@ inline std::function<Virus<TSeq>*(Agent<TSeq>*,Model<TSeq>*)> make_sample_virus_
  * @return Virus<TSeq>* of the selected virus. If none selected (or none
  * available,) returns a nullptr;
  */
-template<typename TSeq = int>
+template<typename TSeq = EPI_DEFAULT_TSEQ>
 inline Virus<TSeq> * sample_virus_single(Agent<TSeq> * p, Model<TSeq> * m)
 {
 

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 2
+#define EPIWORLD_VERSION_PATCH 3
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;
@@ -2126,7 +2126,7 @@ inline void LFMCMC<TData>::print()
     printf_epiworld("___________________________________________\n\n");
     printf_epiworld("LIKELIHOOD-FREE MARKOV CHAIN MONTE CARLO\n\n");
 
-    printf_epiworld("N Samples : %ld\n", n_samples);
+    printf_epiworld("N Samples : %zu\n", n_samples);
 
     std::string abbr;
     epiworld_double elapsed;

--- a/examples/14-community-hosp/Makefile
+++ b/examples/14-community-hosp/Makefile
@@ -1,0 +1,2 @@
+main.o: main.cpp
+	g++ -std=c++17 -O3 -g main.cpp -o main.o

--- a/examples/14-community-hosp/README.md
+++ b/examples/14-community-hosp/README.md
@@ -1,0 +1,99 @@
+# Community-hospital model
+
+In this model, we have three states:
+
+- Susceptible individuals (in the community),
+- Infected individuals (in the community), and
+- Infected hospitalized individuals.
+
+Susceptible individuals may become hospitalized or not (so they have two possible transitions), and infected individuals may recover or (if hospitalized) stay infected but be discharged (so they go back as infected but in the community).
+
+The model has the following parameters:
+
+- Prob hospitalization: 0.1
+- Prob recovery: 0.33
+- Discharge infected: 0.1
+
+Here is an example of the run
+
+```bash
+root ➜ /workspaces/epiworld/examples/14-community-hosp (example-karim) $ make
+g++ -std=c++17 -O3 -g main.cpp -o main.o
+root ➜ /workspaces/epiworld/examples/14-community-hosp (example-karim) $ ./main.o
+_________________________________________________________________________
+Running the model...
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| done.
+ done.
+________________________________________________________________________________
+________________________________________________________________________________
+SIMULATION STUDY
+
+Name of the model   : (none)
+Population size     : 1000
+Agents' data        : (none)
+Number of entities  : 0
+Days (duration)     : 100 (of 100)
+Number of viruses   : 1
+Last run elapsed t  : 4.00ms
+Last run speed      : 20.81 million agents x day / second
+Rewiring            : off
+
+Global events:
+ (none)
+
+Virus(es):
+ - MRSA
+
+Tool(s):
+ (none)
+
+Model parameters:
+ - Discharge infected   : 0.1000
+ - Prob hospitalization : 0.1000
+ - Prob recovery        : 0.3300
+
+Distribution of the population at time 100:
+  - (0) Susceptible             :  990 -> 937
+  - (1) Infected                :   10 -> 49
+  - (2) Infected (hospitalized) :    0 -> 14
+
+Transition Probabilities:
+ - Susceptible              0.98  0.02  0.00
+ - Infected                 0.32  0.61  0.07
+ - Infected (hospitalized)  0.35  0.07  0.58
+```
+
+## Notes
+
+An few key observations from this example.
+
+1. **We have a sampling function that exclude population**. These two functions are used in the update functions so, when susceptible (in the community) sample, the sampling excludes individuals who are hospitalized. Likewise, hospitalized 
+
+
+    ```cpp
+    // A sampler that excludes infected from the hospital
+    auto sampler_suscept = sampler::make_sample_virus_neighbors<>(
+        {States::Infected_Hospitalized}
+        );
+    ```
+
+2. **All update functions are built from scratch**. For instance, susceptible individuals are updated according to the following function:
+
+    ```cpp
+    inline void update_susceptible(Agent<int> * p, Model<int> * m)
+    {
+
+        auto virus = sampler_suscept(p, m);
+        if (virus != nullptr)
+        {
+            if (m->par("Prob hospitalization") > m->runif())
+                p->set_virus(*virus, m, States::Infected_Hospitalized);
+            else
+                p->set_virus(*virus, m, States::Infected);
+        }
+
+
+        return;
+
+    }
+    ```

--- a/examples/14-community-hosp/main.cpp
+++ b/examples/14-community-hosp/main.cpp
@@ -1,0 +1,75 @@
+#include "../../epiworld.hpp"
+
+/***
+ * A concrete example would be a model that includes two populations.
+ * - One, a ‘community’ population and the other,
+ * - a ‘hospital’ population.
+ * In this model, individuals can move from the community to the hospital (admission) and move from the hospital back into the community (discharge). In both settings, there can be an infectious disease process (e.g. SIS), but we would assume that transmission does not occur between the community and the hospital (of course, this could be relaxed in the future). But through admission and discharge, infections in the community impact dynamics in the hospital and the reverse is true as well.
+ */
+
+using namespace epiworld;
+
+template<typename TSeq = EPI_DEFAULT_TSEQ>
+inline void my_suscept(
+    Agent<TSeq> * p,
+    Model<TSeq> * m
+    )
+{
+
+    // Counting how many entities the agent has
+    auto n_entities = p->get_n_entities();
+
+    if (n_entities == 0)
+    {
+        // You can move agents to an entity
+        // p->add_entity(m->get_entity("Hospital"));
+        return;
+
+    }
+
+    Virus<TSeq> * virus = sampler::sample_virus_single<TSeq>(p, m);
+
+    // You can remove them from the entity
+    // p->rm_entity(m->get_entity("Hospital"));
+    
+    if (virus == nullptr)
+        return;
+
+    p->set_virus(*virus, m); 
+
+    return;
+
+}
+
+int main() {
+
+    // Using the mixing model as a baseline
+    Model<> model;
+
+    // model.add_state("Susceptible", default_update_susceptible<>); // State 0
+    model.add_state("Susceptible", my_suscept<>); // State 0
+    model.add_state("Infected", default_update_exposed<>);        // State 1
+
+    Entity<> hospital("Hospital");
+    hospital.set_distribution(distribute_entity_randomly<>(.5, true, true));
+    model.add_entity(hospital);
+
+    // Adding a new virus
+    Virus<> mrsa("MRSA");
+    mrsa.set_state(1, 0, 0);
+    mrsa.set_prob_infecting(.1);
+    mrsa.set_prob_recovery(.33);
+    mrsa.set_distribution(distribute_virus_randomly<>(0.01));
+
+    model.add_virus(mrsa);
+
+    // Add a population
+    model.agents_smallworld(1000, 4, 0.1, false);
+
+    // Adding a new population
+    model.run(100, 1231);
+    model.print();
+
+    return 0;
+
+}

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,7 +8,8 @@ INTELFLAGS=-g -O2
 
 ALL_EXAMPLES=00-hello-world 01-sir 02-sir_multiple_runs 02b-sir_multiple_runs \
 	     03-simple-sir 04-advanced-usage 05-user-data 06-sir-omp 06b-sir-omp \
-	     07-surveillance 10-likelihood-free-mcmc
+	     07-surveillance 10-likelihood-free-mcmc 11-entities 13-genint \
+		 14-community-hosp
 
 all-examples:
 	for f in $(ALL_EXAMPLES); do \

--- a/include/epiworld/agent-meat-virus-sampling.hpp
+++ b/include/epiworld/agent-meat-virus-sampling.hpp
@@ -20,7 +20,7 @@ namespace sampler {
  * @return Virus<TSeq>* of the selected virus. If none selected (or none
  * available,) returns a nullptr;
  */
-template<typename TSeq>
+template<typename TSeq = EPI_DEFAULT_TSEQ>
 inline std::function<void(Agent<TSeq>*,Model<TSeq>*)> make_update_susceptible(
     std::vector< epiworld_fast_uint > exclude = {}
     )
@@ -179,7 +179,7 @@ inline std::function<void(Agent<TSeq>*,Model<TSeq>*)> make_update_susceptible(
  * @return Virus<TSeq>* of the selected virus. If none selected (or none
  * available,) returns a nullptr;
  */
-template<typename TSeq = int>
+template<typename TSeq = EPI_DEFAULT_TSEQ>
 inline std::function<Virus<TSeq>*(Agent<TSeq>*,Model<TSeq>*)> make_sample_virus_neighbors(
     std::vector< epiworld_fast_uint > exclude = {}
 )
@@ -347,7 +347,7 @@ inline std::function<Virus<TSeq>*(Agent<TSeq>*,Model<TSeq>*)> make_sample_virus_
  * @return Virus<TSeq>* of the selected virus. If none selected (or none
  * available,) returns a nullptr;
  */
-template<typename TSeq = int>
+template<typename TSeq = EPI_DEFAULT_TSEQ>
 inline Virus<TSeq> * sample_virus_single(Agent<TSeq> * p, Model<TSeq> * m)
 {
 

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 2
+#define EPIWORLD_VERSION_PATCH 3
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 1
+#define EPIWORLD_VERSION_PATCH 2
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -18,8 +18,8 @@
 
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
-#define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 4
+#define EPIWORLD_VERSION_MINOR 5
+#define EPIWORLD_VERSION_PATCH 0
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -19,7 +19,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 4
-#define EPIWORLD_VERSION_PATCH 3
+#define EPIWORLD_VERSION_PATCH 4
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -177,7 +177,7 @@ private:
         epiworld_double * last_elapsed,
         std::string * unit_abbr,
         bool print
-    );
+    ) const;
 
     void chrono_start();
     void chrono_end();
@@ -235,13 +235,17 @@ public:
     const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
     std::vector< TData > * get_sampled_data() {return sampled_data;};
 
+    const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
+    const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
+
+
     void set_par_names(std::vector< std::string > names);
     void set_stats_names(std::vector< std::string > names);
 
     std::vector< epiworld_double > get_params_mean();
     std::vector< epiworld_double > get_stats_mean();
 
-    void print() ;
+    void print(size_t burnin = 0u) const;
 
 };
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -187,7 +187,8 @@ public:
     void run(
         std::vector< epiworld_double > param_init,
         size_t n_samples_,
-        epiworld_double epsilon_
+        epiworld_double epsilon_,
+        int seed = -1
         );
 
     LFMCMC() {};

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -52,7 +52,7 @@ inline void LFMCMC<TData>::print()
     printf_epiworld("___________________________________________\n\n");
     printf_epiworld("LIKELIHOOD-FREE MARKOV CHAIN MONTE CARLO\n\n");
 
-    printf_epiworld("N Samples : %ld\n", n_samples);
+    printf_epiworld("N Samples : %zu\n", n_samples);
 
     std::string abbr;
     epiworld_double elapsed;

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -2,29 +2,46 @@
 #define LFMCMC_MEAT_PRINT_HPP
 
 template<typename TData>
-inline void LFMCMC<TData>::print()
+inline void LFMCMC<TData>::print(size_t burnin) const
 {
+
     std::vector< epiworld_double > summ_params(n_parameters * 3, 0.0);
     std::vector< epiworld_double > summ_stats(n_statistics * 3, 0.0);
+
+    size_t n_samples_print = n_samples;
+    if (burnin > 0)
+    {
+        if (burnin >= n_samples)
+            throw std::length_error(
+                "The burnin is greater than the number of samples."
+                );
+
+        n_samples_print = n_samples - burnin;
+
+    }
+
+    epiworld_double n_samples_dbl = static_cast< epiworld_double >(
+        n_samples_print
+        );
 
     for (size_t k = 0u; k < n_parameters; ++k)
     {
 
         // Retrieving the relevant parameter
-        std::vector< epiworld_double > par_i(n_samples);
-        for (size_t i = 0u; i < n_samples; ++i)
+        std::vector< epiworld_double > par_i(n_samples_print);
+        for (size_t i = burnin; i < n_samples; ++i)
         {
             par_i[i] = accepted_params[i * n_parameters + k];
-            summ_params[k * 3] += par_i[i]/n_samples;
+            summ_params[k * 3] += par_i[i]/n_samples_dbl;
         }
 
         // Computing the 95% Credible interval
         std::sort(par_i.begin(), par_i.end());
 
         summ_params[k * 3 + 1u] = 
-            par_i[std::floor(.025 * static_cast<epiworld_double>(n_samples))];
+            par_i[std::floor(.025 * n_samples_dbl)];
         summ_params[k * 3 + 2u] = 
-            par_i[std::floor(.975 * static_cast<epiworld_double>(n_samples))];
+            par_i[std::floor(.975 * n_samples_dbl)];
 
     }
 
@@ -32,20 +49,20 @@ inline void LFMCMC<TData>::print()
     {
 
         // Retrieving the relevant parameter
-        std::vector< epiworld_double > stat_k(n_samples);
-        for (size_t i = 0u; i < n_samples; ++i)
+        std::vector< epiworld_double > stat_k(n_samples_print);
+        for (size_t i = burnin; i < n_samples; ++i)
         {
             stat_k[i] = accepted_stats[i * n_statistics + k];
-            summ_stats[k * 3] += stat_k[i]/n_samples;
+            summ_stats[k * 3] += stat_k[i]/n_samples_dbl;
         }
 
         // Computing the 95% Credible interval
         std::sort(stat_k.begin(), stat_k.end());
 
         summ_stats[k * 3 + 1u] = 
-            stat_k[std::floor(.025 * static_cast<epiworld_double>(n_samples))];
+            stat_k[std::floor(.025 * n_samples_dbl)];
         summ_stats[k * 3 + 2u] = 
-            stat_k[std::floor(.975 * static_cast<epiworld_double>(n_samples))];
+            stat_k[std::floor(.975 * n_samples_dbl)];
 
     }
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -5,6 +5,8 @@ template<typename TData>
 inline void LFMCMC<TData>::print(size_t burnin) const
 {
 
+    // The summary statistics will have three values: mean, the 2.5% 
+    // quantile, and the 97.5% quantile
     std::vector< epiworld_double > summ_params(n_parameters * 3, 0.0);
     std::vector< epiworld_double > summ_stats(n_statistics * 3, 0.0);
 
@@ -58,7 +60,6 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
         // Computing the 95% Credible interval
         std::sort(stat_k.begin(), stat_k.end());
-
         summ_stats[k * 3 + 1u] = 
             stat_k[std::floor(.025 * n_samples_dbl)];
         summ_stats[k * 3 + 2u] = 

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -5,17 +5,18 @@ template<typename TData>
 inline void LFMCMC<TData>::print(size_t burnin) const
 {
 
-    // The summary statistics will have three values: mean, the 2.5% 
-    // quantile, and the 97.5% quantile
+    // For each statistic or parameter in the model, we print three values: 
+    // - mean, the 2.5% quantile, and the 97.5% quantile
     std::vector< epiworld_double > summ_params(n_parameters * 3, 0.0);
     std::vector< epiworld_double > summ_stats(n_statistics * 3, 0.0);
 
+    // Compute the number of samples to use based on burnin rate
     size_t n_samples_print = n_samples;
     if (burnin > 0)
     {
         if (burnin >= n_samples)
             throw std::length_error(
-                "The burnin is greater than the number of samples."
+                "The burnin is greater than or equal to the number of samples."
                 );
 
         n_samples_print = n_samples - burnin;
@@ -26,6 +27,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         n_samples_print
         );
 
+    // Compute parameter summary values
     for (size_t k = 0u; k < n_parameters; ++k)
     {
 
@@ -33,8 +35,8 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > par_i(n_samples_print);
         for (size_t i = burnin; i < n_samples; ++i)
         {
-            par_i[i] = accepted_params[i * n_parameters + k];
-            summ_params[k * 3] += par_i[i]/n_samples_dbl;
+            par_i[i-burnin] = accepted_params[i * n_parameters + k];
+            summ_params[k * 3] += par_i[i-burnin]/n_samples_dbl;
         }
 
         // Computing the 95% Credible interval
@@ -47,6 +49,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     }
 
+    // Compute statistics summary values
     for (size_t k = 0u; k < n_statistics; ++k)
     {
 
@@ -54,8 +57,8 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > stat_k(n_samples_print);
         for (size_t i = burnin; i < n_samples; ++i)
         {
-            stat_k[i] = accepted_stats[i * n_statistics + k];
-            summ_stats[k * 3] += stat_k[i]/n_samples_dbl;
+            stat_k[i-burnin] = accepted_stats[i * n_statistics + k];
+            summ_stats[k * 3] += stat_k[i-burnin]/n_samples_dbl;
         }
 
         // Computing the 95% Credible interval

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -205,7 +205,8 @@ template<typename TData>
 inline void LFMCMC<TData>::run(
     std::vector< epiworld_double > params_init_,
     size_t n_samples_,
-    epiworld_double epsilon_
+    epiworld_double epsilon_,
+    int seed
     )
 {
 
@@ -217,6 +218,9 @@ inline void LFMCMC<TData>::run(
     epsilon      = epsilon_;
     params_init  = params_init_;
     n_parameters = params_init_.size();
+
+    if (seed >= 0)
+        this->seed(seed);
 
     params_now.resize(n_parameters);
     params_prev.resize(n_parameters);

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -249,14 +249,16 @@ inline void LFMCMC<TData>::run(
 
     std::vector< epiworld_double > proposed_stats_i;
     summary_fun(proposed_stats_i, data_i, this);
-    accepted_params_prob[0u] = kernel_fun(proposed_stats_i, observed_stats, epsilon, this);
+    accepted_params_prob[0u] = kernel_fun(
+        proposed_stats_i, observed_stats, epsilon, this
+        );
 
     // Recording statistics
     for (size_t i = 0u; i < n_statistics; ++i)
         sampled_stats[i] = proposed_stats_i[i];
 
-    for (size_t k = 0u; k < n_statistics; ++k)
-        accepted_params[k] = proposed_stats_i[k];
+    for (size_t k = 0u; k < n_parameters; ++k)
+        accepted_params[k] = params_init[k];
    
     for (size_t i = 1u; i < n_samples; ++i)
     {
@@ -274,7 +276,10 @@ inline void LFMCMC<TData>::run(
         summary_fun(proposed_stats_i, data_i, this);
 
         // Step 4: Compute the hastings ratio using the kernel function
-        epiworld_double hr = kernel_fun(proposed_stats_i, observed_stats, epsilon, this);
+        epiworld_double hr = kernel_fun(
+            proposed_stats_i, observed_stats, epsilon, this
+            );
+
         sampled_stats_prob[i] = hr;
 
         // Storing data
@@ -282,7 +287,7 @@ inline void LFMCMC<TData>::run(
             sampled_stats[i * n_statistics + k] = proposed_stats_i[k];
         
         // Running Hastings ratio
-        epiworld_double r      = runif();
+        epiworld_double r = runif();
         drawn_prob[i] = r;
 
         // Step 5: Update if likely
@@ -418,7 +423,7 @@ inline void LFMCMC<TData>::get_elapsed(
     epiworld_double * last_elapsed,
     std::string * unit_abbr,
     bool print
-) {
+) const {
 
     // Preparing the result
     epiworld_double elapsed;

--- a/include/epiworld/misc.hpp
+++ b/include/epiworld/misc.hpp
@@ -124,7 +124,7 @@ inline bool IN(const Ta & a, const std::vector< Ta > & b) noexcept
  * @return int If -1 then it means that none got sampled, otherwise the index
  * of the entry that got drawn.
  */
-template<typename TSeq, typename TDbl>
+template<typename TSeq = EPI_DEFAULT_TSEQ, typename TDbl = epiworld_double >
 inline int roulette(
     const std::vector< TDbl > & probs,
     Model<TSeq> * m

--- a/include/epiworld/model-meat.hpp
+++ b/include/epiworld/model-meat.hpp
@@ -714,7 +714,7 @@ template<typename TSeq>
 inline epiworld_double & Model<TSeq>::operator()(std::string pname) {
 
     if (parameters.find(pname) == parameters.end())
-        throw std::range_error("The parameter "+ pname + "is not in the model.");
+        throw std::range_error("The parameter '"+ pname + "' is not in the model.");
 
     return parameters[pname];
 

--- a/tests/00-lfmcmc.cpp
+++ b/tests/00-lfmcmc.cpp
@@ -73,6 +73,8 @@ EPIWORLD_TEST_CASE("LFMCMC", "[Basic example]") {
     std::vector<epiworld_double> expected = {5.0, 1.5};
     REQUIRE_THAT(params_means, Catch::Approx(expected).margin(0.5));
     REQUIRE_THAT(stats_means, Catch::Approx(expected).margin(0.5));
+    REQUIRE_THROWS(model.print(200000));
+    REQUIRE_NOTHROW(model.print(50000));
     #endif 
 
     #ifndef CATCH_CONFIG_MAIN

--- a/tests/00-lfmcmc.cpp
+++ b/tests/00-lfmcmc.cpp
@@ -64,6 +64,7 @@ EPIWORLD_TEST_CASE("LFMCMC", "[Basic example]") {
 
     
     model.print();
+    model.print(50000);
 
     auto params_means = model.get_params_mean();
     auto stats_means  = model.get_stats_mean();


### PR DESCRIPTION
This fixes a couple of bugs. The main one: the vector containing the sampled parameters wrongly contained the first few sampled statistics. We were able to catch this with smaller samples (e.g., 10) where the differences in magnitude were more evident. In addition, it adds a couple of methods for extracting data from the LFMCMC class.

This also includes the example I wrote for @kkhader.