### PR TITLE
Fix naming conventions in LFMCMC for consistency and clarity

### DIFF
--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -18,7 +18,7 @@
 
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
-#define EPIWORLD_VERSION_MINOR 5
+#define EPIWORLD_VERSION_MINOR 6
 #define EPIWORLD_VERSION_PATCH 0
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1190,30 +1190,42 @@ private:
         std::make_shared< std::gamma_distribution<> >();
 
     // Process data
-    TData observed_data;
+    TData m_observed_data;
     
     // Information about the size of the problem
-    size_t n_samples;
-    size_t n_statistics;
-    size_t n_parameters;
+    size_t m_n_samples;
+    size_t m_n_stats;
+    size_t m_n_params;
 
-    epiworld_double epsilon;
+    epiworld_double m_epsilon;
 
+    // params_new/new_params current_params (new_params in proposal function)
     std::vector< epiworld_double > params_now;
+    // params_prev/prev_params maybe params_old/old_params
+    // previous_params
     std::vector< epiworld_double > params_prev;
+    // params_init (no change)
+    // initial_params
     std::vector< epiworld_double > params_init;
 
+    // observed_stats (no change)
     std::vector< epiworld_double > observed_stats; ///< Observed statistics
 
+    // param_samples, stat_samples
     std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
     std::vector< epiworld_double > sampled_stats;      ///< Sampled statistics
+    // What is this?
     std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
+    // accepted_samples
     std::vector< bool >            sampled_accepted;   ///< Indicator of accepted statistics
 
+    // accepted_params, accepted_stats
     std::vector< epiworld_double > accepted_params;      ///< Posterior distribution (accepted samples)
     std::vector< epiworld_double > accepted_stats;       ///< Posterior distribution (accepted samples)
+    // What is this?
     std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
 
+    // No change
     std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
     std::vector< TData > * sampled_data = nullptr;
 
@@ -1224,16 +1236,20 @@ private:
     LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
+    // param_names, stat_names
     std::vector< std::string > names_parameters;
     std::vector< std::string > names_statistics;
 
+    // start_time, end_time (??)
     std::chrono::time_point<std::chrono::steady_clock> time_start;
     std::chrono::time_point<std::chrono::steady_clock> time_end;
 
     // std::chrono::milliseconds
+    // elapsed_time
     std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
         std::chrono::duration<epiworld_double,std::micro>::zero();
 
+    // get_elapsed_time
     inline void get_elapsed(
         std::string unit,
         epiworld_double * last_elapsed,
@@ -1241,6 +1257,7 @@ private:
         bool print
     ) const;
 
+    // start_chrono, end_chrono (??)
     void chrono_start();
     void chrono_end();
     
@@ -1254,10 +1271,10 @@ public:
         );
 
     LFMCMC() {};
-    LFMCMC(const TData & observed_data_) : observed_data(observed_data_) {};
+    LFMCMC(const TData & observed_data_) : m_observed_data(observed_data_) {};
     ~LFMCMC() {};
 
-    void set_observed_data(const TData & observed_data_) {observed_data = observed_data_;};
+    void set_observed_data(const TData & observed_data_) {m_observed_data = observed_data_;};
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
@@ -1282,10 +1299,10 @@ public:
     ///@}
 
     // Accessing parameters of the function
-    size_t get_n_samples() const {return n_samples;};
-    size_t get_n_statistics() const {return n_statistics;};
-    size_t get_n_parameters() const {return n_parameters;};
-    epiworld_double get_epsilon() const {return epsilon;};
+    size_t get_n_samples() const {return m_n_samples;};
+    size_t get_n_stats() const {return m_n_stats;};
+    size_t get_n_params() const {return m_n_params;};
+    epiworld_double get_epsilon() const {return m_epsilon;};
 
     const std::vector< epiworld_double > & get_params_now() {return params_now;};
     const std::vector< epiworld_double > & get_params_prev() {return params_prev;};
@@ -1304,6 +1321,7 @@ public:
     void set_par_names(std::vector< std::string > names);
     void set_stats_names(std::vector< std::string > names);
 
+    // get_mean_params, get_mean_stats
     std::vector< epiworld_double > get_params_mean();
     std::vector< epiworld_double > get_stats_mean();
 
@@ -1472,30 +1490,42 @@ private:
         std::make_shared< std::gamma_distribution<> >();
 
     // Process data
-    TData observed_data;
+    TData m_observed_data;
     
     // Information about the size of the problem
-    size_t n_samples;
-    size_t n_statistics;
-    size_t n_parameters;
+    size_t m_n_samples;
+    size_t m_n_stats;
+    size_t m_n_params;
 
-    epiworld_double epsilon;
+    epiworld_double m_epsilon;
 
+    // params_new/new_params current_params (new_params in proposal function)
     std::vector< epiworld_double > params_now;
+    // params_prev/prev_params maybe params_old/old_params
+    // previous_params
     std::vector< epiworld_double > params_prev;
+    // params_init (no change)
+    // initial_params
     std::vector< epiworld_double > params_init;
 
+    // observed_stats (no change)
     std::vector< epiworld_double > observed_stats; ///< Observed statistics
 
+    // param_samples, stat_samples
     std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
     std::vector< epiworld_double > sampled_stats;      ///< Sampled statistics
+    // What is this?
     std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
+    // accepted_samples
     std::vector< bool >            sampled_accepted;   ///< Indicator of accepted statistics
 
+    // accepted_params, accepted_stats
     std::vector< epiworld_double > accepted_params;      ///< Posterior distribution (accepted samples)
     std::vector< epiworld_double > accepted_stats;       ///< Posterior distribution (accepted samples)
+    // What is this?
     std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
 
+    // No change
     std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
     std::vector< TData > * sampled_data = nullptr;
 
@@ -1506,16 +1536,20 @@ private:
     LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
+    // param_names, stat_names
     std::vector< std::string > names_parameters;
     std::vector< std::string > names_statistics;
 
+    // start_time, end_time (??)
     std::chrono::time_point<std::chrono::steady_clock> time_start;
     std::chrono::time_point<std::chrono::steady_clock> time_end;
 
     // std::chrono::milliseconds
+    // elapsed_time
     std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
         std::chrono::duration<epiworld_double,std::micro>::zero();
 
+    // get_elapsed_time
     inline void get_elapsed(
         std::string unit,
         epiworld_double * last_elapsed,
@@ -1523,6 +1557,7 @@ private:
         bool print
     ) const;
 
+    // start_chrono, end_chrono (??)
     void chrono_start();
     void chrono_end();
     
@@ -1536,10 +1571,10 @@ public:
         );
 
     LFMCMC() {};
-    LFMCMC(const TData & observed_data_) : observed_data(observed_data_) {};
+    LFMCMC(const TData & observed_data_) : m_observed_data(observed_data_) {};
     ~LFMCMC() {};
 
-    void set_observed_data(const TData & observed_data_) {observed_data = observed_data_;};
+    void set_observed_data(const TData & observed_data_) {m_observed_data = observed_data_;};
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
@@ -1564,10 +1599,10 @@ public:
     ///@}
 
     // Accessing parameters of the function
-    size_t get_n_samples() const {return n_samples;};
-    size_t get_n_statistics() const {return n_statistics;};
-    size_t get_n_parameters() const {return n_parameters;};
-    epiworld_double get_epsilon() const {return epsilon;};
+    size_t get_n_samples() const {return m_n_samples;};
+    size_t get_n_stats() const {return m_n_stats;};
+    size_t get_n_params() const {return m_n_params;};
+    epiworld_double get_epsilon() const {return m_epsilon;};
 
     const std::vector< epiworld_double > & get_params_now() {return params_now;};
     const std::vector< epiworld_double > & get_params_prev() {return params_prev;};
@@ -1586,6 +1621,7 @@ public:
     void set_par_names(std::vector< std::string > names);
     void set_stats_names(std::vector< std::string > names);
 
+    // get_mean_params, get_mean_stats
     std::vector< epiworld_double > get_params_mean();
     std::vector< epiworld_double > get_stats_mean();
 
@@ -1618,7 +1654,7 @@ inline void proposal_fun_normal(
     LFMCMC<TData>* m
 ) {
 
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         params_now[p] = params_prev[p] + m->rnorm();
 
     return;
@@ -1651,7 +1687,7 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
         ) {
 
         // Making the proposal
-        for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+        for (size_t p = 0u; p < m->get_n_params(); ++p)
             params_now[p] = params_prev[p] + m->rnorm() * scale;
 
         // Checking boundaries
@@ -1716,7 +1752,7 @@ inline void proposal_fun_unif(
     LFMCMC<TData>* m
 ) {
 
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         params_now[p] = (params_prev[p] + m->runif(-1.0, 1.0));
 
     return;
@@ -1741,7 +1777,7 @@ inline epiworld_double kernel_fun_uniform(
 ) {
 
     epiworld_double ans = 0.0;
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
 
     return std::sqrt(ans) < epsilon ? 1.0 : 0.0;
@@ -1767,7 +1803,7 @@ inline epiworld_double kernel_fun_gaussian(
 ) {
 
     epiworld_double ans = 0.0;
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
 
     return std::exp(
@@ -1815,53 +1851,53 @@ inline void LFMCMC<TData>::run(
     chrono_start();
 
     // Setting the baseline parameters of the model
-    n_samples    = n_samples_;
-    epsilon      = epsilon_;
+    m_n_samples    = n_samples_;
+    m_epsilon      = epsilon_;
     params_init  = params_init_;
-    n_parameters = params_init_.size();
+    m_n_params = params_init_.size();
 
     if (seed >= 0)
         this->seed(seed);
 
-    params_now.resize(n_parameters);
-    params_prev.resize(n_parameters);
+    params_now.resize(m_n_params);
+    params_prev.resize(m_n_params);
 
     if (sampled_data != nullptr)
-        sampled_data->resize(n_samples);
+        sampled_data->resize(m_n_samples);
 
     params_prev = params_init;
     params_now  = params_init;
 
     // Computing the baseline sufficient statistics
-    summary_fun(observed_stats, observed_data, this);
-    n_statistics = observed_stats.size();
+    summary_fun(observed_stats, m_observed_data, this);
+    m_n_stats = observed_stats.size();
 
     // Reserving size
-    drawn_prob.resize(n_samples);
-    sampled_accepted.resize(n_samples, false);
-    sampled_stats.resize(n_samples * n_statistics);
-    sampled_stats_prob.resize(n_samples);
+    drawn_prob.resize(m_n_samples);
+    sampled_accepted.resize(m_n_samples, false);
+    sampled_stats.resize(m_n_samples * m_n_stats);
+    sampled_stats_prob.resize(m_n_samples);
 
-    accepted_params.resize(n_samples * n_parameters);
-    accepted_stats.resize(n_samples * n_statistics);
-    accepted_params_prob.resize(n_samples);
+    accepted_params.resize(m_n_samples * m_n_params);
+    accepted_stats.resize(m_n_samples * m_n_stats);
+    accepted_params_prob.resize(m_n_samples);
 
     TData data_i = simulation_fun(params_init, this);
 
     std::vector< epiworld_double > proposed_stats_i;
     summary_fun(proposed_stats_i, data_i, this);
     accepted_params_prob[0u] = kernel_fun(
-        proposed_stats_i, observed_stats, epsilon, this
+        proposed_stats_i, observed_stats, m_epsilon, this
         );
 
     // Recording statistics
-    for (size_t i = 0u; i < n_statistics; ++i)
+    for (size_t i = 0u; i < m_n_stats; ++i)
         sampled_stats[i] = proposed_stats_i[i];
 
-    for (size_t k = 0u; k < n_parameters; ++k)
+    for (size_t k = 0u; k < m_n_params; ++k)
         accepted_params[k] = params_init[k];
    
-    for (size_t i = 1u; i < n_samples; ++i)
+    for (size_t i = 1u; i < m_n_samples; ++i)
     {
         // Step 1: Generate a proposal and store it in params_now
         proposal_fun(params_now, params_prev, this);
@@ -1878,14 +1914,14 @@ inline void LFMCMC<TData>::run(
 
         // Step 4: Compute the hastings ratio using the kernel function
         epiworld_double hr = kernel_fun(
-            proposed_stats_i, observed_stats, epsilon, this
+            proposed_stats_i, observed_stats, m_epsilon, this
             );
 
         sampled_stats_prob[i] = hr;
 
         // Storing data
-        for (size_t k = 0u; k < n_statistics; ++k)
-            sampled_stats[i * n_statistics + k] = proposed_stats_i[k];
+        for (size_t k = 0u; k < m_n_stats; ++k)
+            sampled_stats[i * m_n_stats + k] = proposed_stats_i[k];
         
         // Running Hastings ratio
         epiworld_double r = runif();
@@ -1897,8 +1933,8 @@ inline void LFMCMC<TData>::run(
             accepted_params_prob[i] = hr;
             sampled_accepted[i]     = true;
             
-            for (size_t k = 0u; k < n_statistics; ++k)
-                accepted_stats[i * n_statistics + k] =
+            for (size_t k = 0u; k < m_n_stats; ++k)
+                accepted_stats[i * m_n_stats + k] =
                     proposed_stats_i[k];
 
             params_prev = params_now;
@@ -1906,16 +1942,16 @@ inline void LFMCMC<TData>::run(
         } else
         {
 
-            for (size_t k = 0u; k < n_statistics; ++k)
-                accepted_stats[i * n_statistics + k] =
-                    accepted_stats[(i - 1) * n_statistics + k];
+            for (size_t k = 0u; k < m_n_stats; ++k)
+                accepted_stats[i * m_n_stats + k] =
+                    accepted_stats[(i - 1) * m_n_stats + k];
 
             accepted_params_prob[i] = accepted_params_prob[i - 1u];
         }
             
 
-        for (size_t k = 0u; k < n_parameters; ++k)
-            accepted_params[i * n_parameters + k] = params_prev[k];
+        for (size_t k = 0u; k < m_n_params; ++k)
+            accepted_params[i * m_n_params + k] = params_prev[k];
 
     }
 
@@ -2094,19 +2130,19 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     // For each statistic or parameter in the model, we print three values: 
     // - mean, the 2.5% quantile, and the 97.5% quantile
-    std::vector< epiworld_double > summ_params(n_parameters * 3, 0.0);
-    std::vector< epiworld_double > summ_stats(n_statistics * 3, 0.0);
+    std::vector< epiworld_double > summ_params(m_n_params * 3, 0.0);
+    std::vector< epiworld_double > summ_stats(m_n_stats * 3, 0.0);
 
     // Compute the number of samples to use based on burnin rate
-    size_t n_samples_print = n_samples;
+    size_t n_samples_print = m_n_samples;
     if (burnin > 0)
     {
-        if (burnin >= n_samples)
+        if (burnin >= m_n_samples)
             throw std::length_error(
                 "The burnin is greater than or equal to the number of samples."
                 );
 
-        n_samples_print = n_samples - burnin;
+        n_samples_print = m_n_samples - burnin;
 
     }
 
@@ -2115,14 +2151,14 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         );
 
     // Compute parameter summary values
-    for (size_t k = 0u; k < n_parameters; ++k)
+    for (size_t k = 0u; k < m_n_params; ++k)
     {
 
         // Retrieving the relevant parameter
         std::vector< epiworld_double > par_i(n_samples_print);
-        for (size_t i = burnin; i < n_samples; ++i)
+        for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            par_i[i-burnin] = accepted_params[i * n_parameters + k];
+            par_i[i-burnin] = accepted_params[i * m_n_params + k];
             summ_params[k * 3] += par_i[i-burnin]/n_samples_dbl;
         }
 
@@ -2137,14 +2173,14 @@ inline void LFMCMC<TData>::print(size_t burnin) const
     }
 
     // Compute statistics summary values
-    for (size_t k = 0u; k < n_statistics; ++k)
+    for (size_t k = 0u; k < m_n_stats; ++k)
     {
 
         // Retrieving the relevant parameter
         std::vector< epiworld_double > stat_k(n_samples_print);
-        for (size_t i = burnin; i < n_samples; ++i)
+        for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            stat_k[i-burnin] = accepted_stats[i * n_statistics + k];
+            stat_k[i-burnin] = accepted_stats[i * m_n_stats + k];
             summ_stats[k * 3] += stat_k[i-burnin]/n_samples_dbl;
         }
 
@@ -2160,7 +2196,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
     printf_epiworld("___________________________________________\n\n");
     printf_epiworld("LIKELIHOOD-FREE MARKOV CHAIN MONTE CARLO\n\n");
 
-    printf_epiworld("N Samples : %zu\n", n_samples);
+    printf_epiworld("N Samples : %zu\n", m_n_samples);
 
     std::string abbr;
     epiworld_double elapsed;
@@ -2204,7 +2240,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (initial : % ") +
             charlen + std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_parameters; ++k)
+        for (size_t k = 0u; k < m_n_params; ++k)
         {
             printf_epiworld(
                 fmt_params.c_str(),
@@ -2225,7 +2261,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (initial : % ") + charlen +
             std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_parameters; ++k)
+        for (size_t k = 0u; k < m_n_params; ++k)
         {
             
             printf_epiworld(
@@ -2276,7 +2312,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (Observed: % ") + nchar_char +
             std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_statistics; ++k)
+        for (size_t k = 0u; k < m_n_stats; ++k)
         {
             printf_epiworld(
                 fmt_stats.c_str(),
@@ -2298,7 +2334,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (Observed: % ") + nchar_char +
             std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_statistics; ++k)
+        for (size_t k = 0u; k < m_n_stats; ++k)
         {
             printf_epiworld(
                 fmt_stats.c_str(),
@@ -2341,7 +2377,7 @@ template<typename TData>
 inline void LFMCMC<TData>::set_par_names(std::vector< std::string > names)
 {
 
-    if (names.size() != n_parameters)
+    if (names.size() != m_n_params)
         throw std::length_error("The number of names to add differs from the number of parameters in the model.");
 
     names_parameters = names;
@@ -2351,7 +2387,7 @@ template<typename TData>
 inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
 {
 
-    if (names.size() != n_statistics)
+    if (names.size() != m_n_stats)
         throw std::length_error("The number of names to add differs from the number of statistics in the model.");
 
     names_statistics = names;
@@ -2361,13 +2397,13 @@ inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
 template<typename TData>
 inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
 {
-    std::vector< epiworld_double > res(this->n_parameters, 0.0);
+    std::vector< epiworld_double > res(this->m_n_params, 0.0);
     
-    for (size_t k = 0u; k < n_parameters; ++k)
+    for (size_t k = 0u; k < m_n_params; ++k)
     {
-        for (size_t i = 0u; i < n_samples; ++i)
-            res[k] += (this->accepted_params[k + n_parameters * i])/
-                static_cast< epiworld_double >(n_samples);
+        for (size_t i = 0u; i < m_n_samples; ++i)
+            res[k] += (this->accepted_params[k + m_n_params * i])/
+                static_cast< epiworld_double >(m_n_samples);
     }
 
     return res;
@@ -2377,13 +2413,13 @@ inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
 template<typename TData>
 inline std::vector< epiworld_double > LFMCMC<TData>::get_stats_mean()
 {
-    std::vector< epiworld_double > res(this->n_statistics, 0.0);
+    std::vector< epiworld_double > res(this->m_n_stats, 0.0);
     
-    for (size_t k = 0u; k < n_statistics; ++k)
+    for (size_t k = 0u; k < m_n_stats; ++k)
     {
-        for (size_t i = 0u; i < n_samples; ++i)
-            res[k] += (this->accepted_stats[k + n_statistics * i])/
-                static_cast< epiworld_double >(n_samples);
+        for (size_t i = 0u; i < m_n_samples; ++i)
+            res[k] += (this->accepted_stats[k + m_n_stats * i])/
+                static_cast< epiworld_double >(m_n_samples);
     }
 
     return res;

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1205,17 +1205,14 @@ private:
 
     std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
 
-    // param_samples, stat_samples
-    std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
-    std::vector< epiworld_double > sampled_stats;      ///< Sampled statistics
+    std::vector< epiworld_double > m_param_samples;     ///< Sampled Parameters
+    std::vector< epiworld_double > m_stat_samples;      ///< Sampled statistics
     // What is this?
     std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
-    // accepted_samples
-    std::vector< bool >            sampled_accepted;   ///< Indicator of accepted statistics
+    std::vector< bool >            m_sample_acceptance;   ///< Indicator of accepted statistics
 
-    // accepted_params, accepted_stats
-    std::vector< epiworld_double > accepted_params;      ///< Posterior distribution (accepted samples)
-    std::vector< epiworld_double > accepted_stats;       ///< Posterior distribution (accepted samples)
+    std::vector< epiworld_double > m_accepted_params;      ///< Posterior distribution (accepted samples)
+    std::vector< epiworld_double > m_accepted_stats;       ///< Posterior distribution (accepted samples)
     // What is this?
     std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
 
@@ -1233,17 +1230,14 @@ private:
     std::vector< std::string > m_param_names;
     std::vector< std::string > m_stat_names;
 
-    // start_time, end_time (??)
-    std::chrono::time_point<std::chrono::steady_clock> time_start;
-    std::chrono::time_point<std::chrono::steady_clock> time_end;
+    std::chrono::time_point<std::chrono::steady_clock> m_start_time;
+    std::chrono::time_point<std::chrono::steady_clock> m_end_time;
 
     // std::chrono::milliseconds
-    // elapsed_time
-    std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
+    std::chrono::duration<epiworld_double,std::micro> m_elapsed_time = 
         std::chrono::duration<epiworld_double,std::micro>::zero();
 
-    // get_elapsed_time
-    inline void get_elapsed(
+    inline void get_elapsed_time(
         std::string unit,
         epiworld_double * last_elapsed,
         std::string * unit_abbr,
@@ -1301,14 +1295,16 @@ public:
     const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
     const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
-    const std::vector< epiworld_double > & get_statistics_hist() {return sampled_stats;};
-    const std::vector< bool >            & get_statistics_accepted() {return sampled_accepted;};
+
+    const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
+    const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
+    const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
     const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
     const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
     std::vector< TData > * get_sampled_data() {return sampled_data;};
 
-    const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
-    const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
+    const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
+    const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
 
     void set_param_names(std::vector< std::string > names);
     void set_stat_names(std::vector< std::string > names);
@@ -1496,17 +1492,14 @@ private:
 
     std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
 
-    // param_samples, stat_samples
-    std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
-    std::vector< epiworld_double > sampled_stats;      ///< Sampled statistics
+    std::vector< epiworld_double > m_param_samples;     ///< Sampled Parameters
+    std::vector< epiworld_double > m_stat_samples;      ///< Sampled statistics
     // What is this?
     std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
-    // accepted_samples
-    std::vector< bool >            sampled_accepted;   ///< Indicator of accepted statistics
+    std::vector< bool >            m_sample_acceptance;   ///< Indicator of accepted statistics
 
-    // accepted_params, accepted_stats
-    std::vector< epiworld_double > accepted_params;      ///< Posterior distribution (accepted samples)
-    std::vector< epiworld_double > accepted_stats;       ///< Posterior distribution (accepted samples)
+    std::vector< epiworld_double > m_accepted_params;      ///< Posterior distribution (accepted samples)
+    std::vector< epiworld_double > m_accepted_stats;       ///< Posterior distribution (accepted samples)
     // What is this?
     std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
 
@@ -1524,17 +1517,14 @@ private:
     std::vector< std::string > m_param_names;
     std::vector< std::string > m_stat_names;
 
-    // start_time, end_time (??)
-    std::chrono::time_point<std::chrono::steady_clock> time_start;
-    std::chrono::time_point<std::chrono::steady_clock> time_end;
+    std::chrono::time_point<std::chrono::steady_clock> m_start_time;
+    std::chrono::time_point<std::chrono::steady_clock> m_end_time;
 
     // std::chrono::milliseconds
-    // elapsed_time
-    std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
+    std::chrono::duration<epiworld_double,std::micro> m_elapsed_time = 
         std::chrono::duration<epiworld_double,std::micro>::zero();
 
-    // get_elapsed_time
-    inline void get_elapsed(
+    inline void get_elapsed_time(
         std::string unit,
         epiworld_double * last_elapsed,
         std::string * unit_abbr,
@@ -1592,14 +1582,16 @@ public:
     const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
     const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
-    const std::vector< epiworld_double > & get_statistics_hist() {return sampled_stats;};
-    const std::vector< bool >            & get_statistics_accepted() {return sampled_accepted;};
+
+    const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
+    const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
+    const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
     const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
     const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
     std::vector< TData > * get_sampled_data() {return sampled_data;};
 
-    const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
-    const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
+    const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
+    const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
 
     void set_param_names(std::vector< std::string > names);
     void set_stat_names(std::vector< std::string > names);
@@ -1856,12 +1848,12 @@ inline void LFMCMC<TData>::run(
 
     // Reserving size
     drawn_prob.resize(m_n_samples);
-    sampled_accepted.resize(m_n_samples, false);
-    sampled_stats.resize(m_n_samples * m_n_stats);
+    m_sample_acceptance.resize(m_n_samples, false);
+    m_stat_samples.resize(m_n_samples * m_n_stats);
     sampled_stats_prob.resize(m_n_samples);
 
-    accepted_params.resize(m_n_samples * m_n_params);
-    accepted_stats.resize(m_n_samples * m_n_stats);
+    m_accepted_params.resize(m_n_samples * m_n_params);
+    m_accepted_stats.resize(m_n_samples * m_n_stats);
     accepted_params_prob.resize(m_n_samples);
 
     TData data_i = simulation_fun(m_initial_params, this);
@@ -1874,10 +1866,10 @@ inline void LFMCMC<TData>::run(
 
     // Recording statistics
     for (size_t i = 0u; i < m_n_stats; ++i)
-        sampled_stats[i] = proposed_stats_i[i];
+        m_stat_samples[i] = proposed_stats_i[i];
 
     for (size_t k = 0u; k < m_n_params; ++k)
-        accepted_params[k] = m_initial_params[k];
+        m_accepted_params[k] = m_initial_params[k];
    
     for (size_t i = 1u; i < m_n_samples; ++i)
     {
@@ -1903,7 +1895,7 @@ inline void LFMCMC<TData>::run(
 
         // Storing data
         for (size_t k = 0u; k < m_n_stats; ++k)
-            sampled_stats[i * m_n_stats + k] = proposed_stats_i[k];
+            m_stat_samples[i * m_n_stats + k] = proposed_stats_i[k];
         
         // Running Hastings ratio
         epiworld_double r = runif();
@@ -1913,10 +1905,10 @@ inline void LFMCMC<TData>::run(
         if (r < std::min(static_cast<epiworld_double>(1.0), hr / accepted_params_prob[i - 1u]))
         {
             accepted_params_prob[i] = hr;
-            sampled_accepted[i]     = true;
+            m_sample_acceptance[i]     = true;
             
             for (size_t k = 0u; k < m_n_stats; ++k)
-                accepted_stats[i * m_n_stats + k] =
+                m_accepted_stats[i * m_n_stats + k] =
                     proposed_stats_i[k];
 
             m_previous_params = m_current_params;
@@ -1925,15 +1917,15 @@ inline void LFMCMC<TData>::run(
         {
 
             for (size_t k = 0u; k < m_n_stats; ++k)
-                accepted_stats[i * m_n_stats + k] =
-                    accepted_stats[(i - 1) * m_n_stats + k];
+                m_accepted_stats[i * m_n_stats + k] =
+                    m_accepted_stats[(i - 1) * m_n_stats + k];
 
             accepted_params_prob[i] = accepted_params_prob[i - 1u];
         }
             
 
         for (size_t k = 0u; k < m_n_params; ++k)
-            accepted_params[i * m_n_params + k] = m_previous_params[k];
+            m_accepted_params[i * m_n_params + k] = m_previous_params[k];
 
     }
 
@@ -2033,11 +2025,11 @@ inline std::shared_ptr< std::mt19937 > & LFMCMC<TData>::get_rand_endgine()
 
 #define DURCAST(tunit,txtunit) {\
         elapsed       = std::chrono::duration_cast<std::chrono:: tunit>(\
-            time_end - time_start).count(); \
+            m_end_time - m_start_time).count(); \
         abbr_unit     = txtunit;}
 
 template<typename TData>
-inline void LFMCMC<TData>::get_elapsed(
+inline void LFMCMC<TData>::get_elapsed_time(
     std::string unit,
     epiworld_double * last_elapsed,
     std::string * unit_abbr,
@@ -2053,7 +2045,7 @@ inline void LFMCMC<TData>::get_elapsed(
     {
 
         size_t tlength = std::to_string(
-            static_cast<int>(floor(time_elapsed.count()))
+            static_cast<int>(floor(m_elapsed_time.count()))
             ).length();
         
         if (tlength <= 1)
@@ -2140,7 +2132,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > par_i(n_samples_print);
         for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            par_i[i-burnin] = accepted_params[i * m_n_params + k];
+            par_i[i-burnin] = m_accepted_params[i * m_n_params + k];
             summ_params[k * 3] += par_i[i-burnin]/n_samples_dbl;
         }
 
@@ -2162,7 +2154,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > stat_k(n_samples_print);
         for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            stat_k[i-burnin] = accepted_stats[i * m_n_stats + k];
+            stat_k[i-burnin] = m_accepted_stats[i * m_n_stats + k];
             summ_stats[k * 3] += stat_k[i-burnin]/n_samples_dbl;
         }
 
@@ -2182,7 +2174,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     std::string abbr;
     epiworld_double elapsed;
-    get_elapsed("auto", &elapsed, &abbr, false);
+    get_elapsed_time("auto", &elapsed, &abbr, false);
     printf_epiworld("Elapsed t : %.2f%s\n\n", elapsed, abbr.c_str());
     
     ////////////////////////////////////////////////////////////////////////////
@@ -2346,13 +2338,13 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
 template<typename TData>
 inline void LFMCMC<TData>::chrono_start() {
-    time_start = std::chrono::steady_clock::now();
+    m_start_time = std::chrono::steady_clock::now();
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::chrono_end() {
-    time_end = std::chrono::steady_clock::now();
-    time_elapsed += (time_end - time_start);
+    m_end_time = std::chrono::steady_clock::now();
+    m_elapsed_time += (m_end_time - m_start_time);
 }
 
 template<typename TData>
@@ -2384,7 +2376,7 @@ inline std::vector< epiworld_double > LFMCMC<TData>::get_mean_params()
     for (size_t k = 0u; k < m_n_params; ++k)
     {
         for (size_t i = 0u; i < m_n_samples; ++i)
-            res[k] += (this->accepted_params[k + m_n_params * i])/
+            res[k] += (this->m_accepted_params[k + m_n_params * i])/
                 static_cast< epiworld_double >(m_n_samples);
     }
 
@@ -2400,7 +2392,7 @@ inline std::vector< epiworld_double > LFMCMC<TData>::get_mean_stats()
     for (size_t k = 0u; k < m_n_stats; ++k)
     {
         for (size_t i = 0u; i < m_n_samples; ++i)
-            res[k] += (this->accepted_stats[k + m_n_stats * i])/
+            res[k] += (this->m_accepted_stats[k + m_n_stats * i])/
                 static_cast< epiworld_double >(m_n_samples);
     }
 

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1137,17 +1137,17 @@ inline void proposal_fun_unif(
 /**
  * @brief Uses the uniform kernel with euclidean distance
  * 
- * @param stats_now Vector of current statistics based on 
- * simulated data.
- * @param stats_obs Vector of observed statistics
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
  * @param epsilon Epsilon parameter
- * @param m LFMCMC model.
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_uniform(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 );
@@ -1156,14 +1156,17 @@ inline epiworld_double kernel_fun_uniform(
  * @brief Gaussian kernel
  * 
  * @tparam TData 
- * @param epsilon 
- * @param m 
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
+ * @param epsilon Epsilon parameter
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_gaussian(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 );
@@ -1425,17 +1428,17 @@ inline void proposal_fun_unif(
 /**
  * @brief Uses the uniform kernel with euclidean distance
  * 
- * @param stats_now Vector of current statistics based on 
- * simulated data.
- * @param stats_obs Vector of observed statistics
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
  * @param epsilon Epsilon parameter
- * @param m LFMCMC model.
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_uniform(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 );
@@ -1444,14 +1447,17 @@ inline epiworld_double kernel_fun_uniform(
  * @brief Gaussian kernel
  * 
  * @tparam TData 
- * @param epsilon 
- * @param m 
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
+ * @param epsilon Epsilon parameter
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_gaussian(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 );
@@ -1737,24 +1743,24 @@ inline void proposal_fun_unif(
 /**
  * @brief Uses the uniform kernel with euclidean distance
  * 
- * @param stats_now Vector of current statistics based on 
- * simulated data.
- * @param stats_obs Vector of observed statistics
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
  * @param epsilon Epsilon parameter
- * @param m LFMCMC model.
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_uniform(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 ) {
 
     epiworld_double ans = 0.0;
     for (size_t p = 0u; p < m->get_n_params(); ++p)
-        ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
+        ans += std::pow(observed_stats[p] - simulated_stats[p], 2.0);
 
     return std::sqrt(ans) < epsilon ? 1.0 : 0.0;
 
@@ -1766,21 +1772,24 @@ inline epiworld_double kernel_fun_uniform(
  * @brief Gaussian kernel
  * 
  * @tparam TData 
- * @param epsilon 
- * @param m 
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
+ * @param epsilon Epsilon parameter
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_gaussian(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 ) {
 
     epiworld_double ans = 0.0;
     for (size_t p = 0u; p < m->get_n_params(); ++p)
-        ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
+        ans += std::pow(observed_stats[p] - simulated_stats[p], 2.0);
 
     return std::exp(
         -.5 * (ans/std::pow(1 + std::pow(epsilon, 2.0)/3.0, 2.0))

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1199,22 +1199,20 @@ private:
 
     epiworld_double m_epsilon;
 
-    std::vector< epiworld_double > m_current_params;
-    std::vector< epiworld_double > m_previous_params;
-    std::vector< epiworld_double > m_initial_params;
+    std::vector< epiworld_double > m_initial_params;            ///< Initial parameters
+    std::vector< epiworld_double > m_current_params;            ///< Parameters for the current sample
+    std::vector< epiworld_double > m_previous_params;           ///< Parameters from the previous sample
 
-    std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
+    std::vector< epiworld_double > m_observed_stats;            ///< Observed statistics
 
-    std::vector< epiworld_double > m_param_samples;     ///< Sampled Parameters
-    std::vector< epiworld_double > m_stat_samples;      ///< Sampled statistics
-    // What is this?
-    std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
-    std::vector< bool >            m_sample_acceptance;   ///< Indicator of accepted statistics
+    std::vector< epiworld_double > m_param_samples;             ///< Sampled parameters
+    std::vector< epiworld_double > m_stat_samples;              ///< Sampled statistics
+    std::vector< bool >            m_sample_acceptance;         ///< Indicator if sample was accepted
+    std::vector< epiworld_double > m_sample_kernel_scores;      ///< Kernel scores for each sample
 
-    std::vector< epiworld_double > m_accepted_params;      ///< Posterior distribution (accepted samples)
-    std::vector< epiworld_double > m_accepted_stats;       ///< Posterior distribution (accepted samples)
-    // What is this?
-    std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
+    std::vector< epiworld_double > m_accepted_params;           ///< Posterior distribution of parameters from accepted samples
+    std::vector< epiworld_double > m_accepted_stats;            ///< Posterior distribution of statistics from accepted samples
+    std::vector< epiworld_double > m_accepted_kernel_scores;    ///< Kernel scores for each accepted sample
 
     // No change
     std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
@@ -1250,7 +1248,7 @@ private:
 public:
 
     void run(
-        std::vector< epiworld_double > param_init,
+        std::vector< epiworld_double > params_init_,
         size_t n_samples_,
         epiworld_double epsilon_,
         int seed = -1
@@ -1290,20 +1288,23 @@ public:
     size_t get_n_params() const {return m_n_params;};
     epiworld_double get_epsilon() const {return m_epsilon;};
 
+    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
     const std::vector< epiworld_double > & get_current_params() {return m_current_params;};
     const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
-    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
+
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
 
     const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
     const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
     const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
-    const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
-    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
-    std::vector< TData > * get_sampled_data() {return sampled_data;};
+    const std::vector< epiworld_double > & get_sample_kernel_scores() {return m_sample_kernel_scores;};
 
     const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
+    const std::vector< epiworld_double > & get_accepted_kernel_scores() {return m_accepted_kernel_scores;};
+    
+    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
+    std::vector< TData > * get_sampled_data() {return sampled_data;};
 
     void set_param_names(std::vector< std::string > names);
     void set_stat_names(std::vector< std::string > names);
@@ -1485,22 +1486,20 @@ private:
 
     epiworld_double m_epsilon;
 
-    std::vector< epiworld_double > m_current_params;
-    std::vector< epiworld_double > m_previous_params;
-    std::vector< epiworld_double > m_initial_params;
+    std::vector< epiworld_double > m_initial_params;            ///< Initial parameters
+    std::vector< epiworld_double > m_current_params;            ///< Parameters for the current sample
+    std::vector< epiworld_double > m_previous_params;           ///< Parameters from the previous sample
 
-    std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
+    std::vector< epiworld_double > m_observed_stats;            ///< Observed statistics
 
-    std::vector< epiworld_double > m_param_samples;     ///< Sampled Parameters
-    std::vector< epiworld_double > m_stat_samples;      ///< Sampled statistics
-    // What is this?
-    std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
-    std::vector< bool >            m_sample_acceptance;   ///< Indicator of accepted statistics
+    std::vector< epiworld_double > m_param_samples;             ///< Sampled parameters
+    std::vector< epiworld_double > m_stat_samples;              ///< Sampled statistics
+    std::vector< bool >            m_sample_acceptance;         ///< Indicator if sample was accepted
+    std::vector< epiworld_double > m_sample_kernel_scores;      ///< Kernel scores for each sample
 
-    std::vector< epiworld_double > m_accepted_params;      ///< Posterior distribution (accepted samples)
-    std::vector< epiworld_double > m_accepted_stats;       ///< Posterior distribution (accepted samples)
-    // What is this?
-    std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
+    std::vector< epiworld_double > m_accepted_params;           ///< Posterior distribution of parameters from accepted samples
+    std::vector< epiworld_double > m_accepted_stats;            ///< Posterior distribution of statistics from accepted samples
+    std::vector< epiworld_double > m_accepted_kernel_scores;    ///< Kernel scores for each accepted sample
 
     // No change
     std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
@@ -1536,7 +1535,7 @@ private:
 public:
 
     void run(
-        std::vector< epiworld_double > param_init,
+        std::vector< epiworld_double > params_init_,
         size_t n_samples_,
         epiworld_double epsilon_,
         int seed = -1
@@ -1576,20 +1575,23 @@ public:
     size_t get_n_params() const {return m_n_params;};
     epiworld_double get_epsilon() const {return m_epsilon;};
 
+    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
     const std::vector< epiworld_double > & get_current_params() {return m_current_params;};
     const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
-    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
+
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
 
     const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
     const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
     const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
-    const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
-    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
-    std::vector< TData > * get_sampled_data() {return sampled_data;};
+    const std::vector< epiworld_double > & get_sample_kernel_scores() {return m_sample_kernel_scores;};
 
     const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
+    const std::vector< epiworld_double > & get_accepted_kernel_scores() {return m_accepted_kernel_scores;};
+    
+    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
+    std::vector< TData > * get_sampled_data() {return sampled_data;};
 
     void set_param_names(std::vector< std::string > names);
     void set_stat_names(std::vector< std::string > names);
@@ -1848,17 +1850,17 @@ inline void LFMCMC<TData>::run(
     drawn_prob.resize(m_n_samples);
     m_sample_acceptance.resize(m_n_samples, false);
     m_stat_samples.resize(m_n_samples * m_n_stats);
-    sampled_stats_prob.resize(m_n_samples);
+    m_sample_kernel_scores.resize(m_n_samples);
 
     m_accepted_params.resize(m_n_samples * m_n_params);
     m_accepted_stats.resize(m_n_samples * m_n_stats);
-    accepted_params_prob.resize(m_n_samples);
+    m_accepted_kernel_scores.resize(m_n_samples);
 
     TData data_i = m_simulation_fun(m_initial_params, this);
 
     std::vector< epiworld_double > proposed_stats_i;
     m_summary_fun(proposed_stats_i, data_i, this);
-    accepted_params_prob[0u] = m_kernel_fun(
+    m_accepted_kernel_scores[0u] = m_kernel_fun(
         proposed_stats_i, m_observed_stats, m_epsilon, this
         );
 
@@ -1889,7 +1891,7 @@ inline void LFMCMC<TData>::run(
             proposed_stats_i, m_observed_stats, m_epsilon, this
             );
 
-        sampled_stats_prob[i] = hr;
+        m_sample_kernel_scores[i] = hr;
 
         // Storing data
         for (size_t k = 0u; k < m_n_stats; ++k)
@@ -1900,9 +1902,9 @@ inline void LFMCMC<TData>::run(
         drawn_prob[i] = r;
 
         // Step 5: Update if likely
-        if (r < std::min(static_cast<epiworld_double>(1.0), hr / accepted_params_prob[i - 1u]))
+        if (r < std::min(static_cast<epiworld_double>(1.0), hr / m_accepted_kernel_scores[i - 1u]))
         {
-            accepted_params_prob[i] = hr;
+            m_accepted_kernel_scores[i] = hr;
             m_sample_acceptance[i]     = true;
             
             for (size_t k = 0u; k < m_n_stats; ++k)
@@ -1918,7 +1920,7 @@ inline void LFMCMC<TData>::run(
                 m_accepted_stats[i * m_n_stats + k] =
                     m_accepted_stats[(i - 1) * m_n_stats + k];
 
-            accepted_params_prob[i] = accepted_params_prob[i - 1u];
+            m_accepted_kernel_scores[i] = m_accepted_kernel_scores[i - 1u];
         }
             
 

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1230,9 +1230,8 @@ private:
     LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
-    // param_names, stat_names
-    std::vector< std::string > names_parameters;
-    std::vector< std::string > names_statistics;
+    std::vector< std::string > m_param_names;
+    std::vector< std::string > m_stat_names;
 
     // start_time, end_time (??)
     std::chrono::time_point<std::chrono::steady_clock> time_start;
@@ -1311,13 +1310,11 @@ public:
     const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
 
+    void set_param_names(std::vector< std::string > names);
+    void set_stat_names(std::vector< std::string > names);
 
-    void set_par_names(std::vector< std::string > names);
-    void set_stats_names(std::vector< std::string > names);
-
-    // get_mean_params, get_mean_stats
-    std::vector< epiworld_double > get_params_mean();
-    std::vector< epiworld_double > get_stats_mean();
+    std::vector< epiworld_double > get_mean_params();
+    std::vector< epiworld_double > get_mean_stats();
 
     void print(size_t burnin = 0u) const;
 
@@ -1524,9 +1521,8 @@ private:
     LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
-    // param_names, stat_names
-    std::vector< std::string > names_parameters;
-    std::vector< std::string > names_statistics;
+    std::vector< std::string > m_param_names;
+    std::vector< std::string > m_stat_names;
 
     // start_time, end_time (??)
     std::chrono::time_point<std::chrono::steady_clock> time_start;
@@ -1605,13 +1601,11 @@ public:
     const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
 
+    void set_param_names(std::vector< std::string > names);
+    void set_stat_names(std::vector< std::string > names);
 
-    void set_par_names(std::vector< std::string > names);
-    void set_stats_names(std::vector< std::string > names);
-
-    // get_mean_params, get_mean_stats
-    std::vector< epiworld_double > get_params_mean();
-    std::vector< epiworld_double > get_stats_mean();
+    std::vector< epiworld_double > get_mean_params();
+    std::vector< epiworld_double > get_mean_stats();
 
     void print(size_t burnin = 0u) const;
 
@@ -2210,10 +2204,10 @@ inline void LFMCMC<TData>::print(size_t burnin) const
     nchar_par_num += 5; // 1 for neg padd, 2 for decimals, 1 the decimal point, and one b/c log(<10) < 1.
     std::string charlen = std::to_string(nchar_par_num);
 
-    if (names_parameters.size() != 0u)
+    if (m_param_names.size() != 0u)
     {
         int nchar_par = 0;
-        for (auto & n : names_parameters)
+        for (auto & n : m_param_names)
         {
             int tmp_nchar = n.length();
             if (nchar_par < tmp_nchar)
@@ -2232,7 +2226,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         {
             printf_epiworld(
                 fmt_params.c_str(),
-                names_parameters[k].c_str(),
+                m_param_names[k].c_str(),
                 summ_params[k * 3],
                 summ_params[k * 3 + 1u],
                 summ_params[k * 3 + 2u],
@@ -2282,10 +2276,10 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     // Figuring out format
     std::string fmt_stats;
-    if (names_statistics.size() != 0u)
+    if (m_stat_names.size() != 0u)
     {
         int nchar_stats = 0;
-        for (auto & n : names_statistics)
+        for (auto & n : m_stat_names)
         {
             int tmp_nchar = n.length();
             if (nchar_stats < tmp_nchar)
@@ -2304,7 +2298,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         {
             printf_epiworld(
                 fmt_stats.c_str(),
-                names_statistics[k].c_str(),
+                m_stat_names[k].c_str(),
                 summ_stats[k * 3],
                 summ_stats[k * 3 + 1u],
                 summ_stats[k * 3 + 2u],
@@ -2362,28 +2356,28 @@ inline void LFMCMC<TData>::chrono_end() {
 }
 
 template<typename TData>
-inline void LFMCMC<TData>::set_par_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_param_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_params)
         throw std::length_error("The number of names to add differs from the number of parameters in the model.");
 
-    names_parameters = names;
+    m_param_names = names;
 
 }
 template<typename TData>
-inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_stat_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_stats)
         throw std::length_error("The number of names to add differs from the number of statistics in the model.");
 
-    names_statistics = names;
+    m_stat_names = names;
 
 }
 
 template<typename TData>
-inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
+inline std::vector< epiworld_double > LFMCMC<TData>::get_mean_params()
 {
     std::vector< epiworld_double > res(this->m_n_params, 0.0);
     
@@ -2399,7 +2393,7 @@ inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
 }
 
 template<typename TData>
-inline std::vector< epiworld_double > LFMCMC<TData>::get_stats_mean()
+inline std::vector< epiworld_double > LFMCMC<TData>::get_mean_stats()
 {
     std::vector< epiworld_double > res(this->m_n_stats, 0.0);
     

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1221,10 +1221,10 @@ private:
     std::vector< TData > * sampled_data = nullptr;
 
     // Functions
-    LFMCMCSimFun<TData> simulation_fun;
-    LFMCMCSummaryFun<TData> summary_fun;
-    LFMCMCProposalFun<TData> proposal_fun = proposal_fun_normal<TData>;
-    LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
+    LFMCMCSimFun<TData> m_simulation_fun;
+    LFMCMCSummaryFun<TData> m_summary_fun;
+    LFMCMCProposalFun<TData> m_proposal_fun = proposal_fun_normal<TData>;
+    LFMCMCKernelFun<TData> m_kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
     std::vector< std::string > m_param_names;
@@ -1508,10 +1508,10 @@ private:
     std::vector< TData > * sampled_data = nullptr;
 
     // Functions
-    LFMCMCSimFun<TData> simulation_fun;
-    LFMCMCSummaryFun<TData> summary_fun;
-    LFMCMCProposalFun<TData> proposal_fun = proposal_fun_normal<TData>;
-    LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
+    LFMCMCSimFun<TData> m_simulation_fun;
+    LFMCMCSummaryFun<TData> m_summary_fun;
+    LFMCMCProposalFun<TData> m_proposal_fun = proposal_fun_normal<TData>;
+    LFMCMCKernelFun<TData> m_kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
     std::vector< std::string > m_param_names;
@@ -1790,25 +1790,25 @@ inline epiworld_double kernel_fun_gaussian(
 template<typename TData>
 inline void LFMCMC<TData>::set_proposal_fun(LFMCMCProposalFun<TData> fun)
 {
-    proposal_fun = fun;
+    m_proposal_fun = fun;
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_simulation_fun(LFMCMCSimFun<TData> fun)
 {
-    simulation_fun = fun;
+    m_simulation_fun = fun;
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_summary_fun(LFMCMCSummaryFun<TData> fun)
 {
-    summary_fun = fun;
+    m_summary_fun = fun;
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_kernel_fun(LFMCMCKernelFun<TData> fun)
 {
-    kernel_fun = fun;
+    m_kernel_fun = fun;
 }
 
 
@@ -1843,7 +1843,7 @@ inline void LFMCMC<TData>::run(
     m_current_params  = m_initial_params;
 
     // Computing the baseline sufficient statistics
-    summary_fun(m_observed_stats, m_observed_data, this);
+    m_summary_fun(m_observed_stats, m_observed_data, this);
     m_n_stats = m_observed_stats.size();
 
     // Reserving size
@@ -1856,11 +1856,11 @@ inline void LFMCMC<TData>::run(
     m_accepted_stats.resize(m_n_samples * m_n_stats);
     accepted_params_prob.resize(m_n_samples);
 
-    TData data_i = simulation_fun(m_initial_params, this);
+    TData data_i = m_simulation_fun(m_initial_params, this);
 
     std::vector< epiworld_double > proposed_stats_i;
-    summary_fun(proposed_stats_i, data_i, this);
-    accepted_params_prob[0u] = kernel_fun(
+    m_summary_fun(proposed_stats_i, data_i, this);
+    accepted_params_prob[0u] = m_kernel_fun(
         proposed_stats_i, m_observed_stats, m_epsilon, this
         );
 
@@ -1874,20 +1874,20 @@ inline void LFMCMC<TData>::run(
     for (size_t i = 1u; i < m_n_samples; ++i)
     {
         // Step 1: Generate a proposal and store it in m_current_params
-        proposal_fun(m_current_params, m_previous_params, this);
+        m_proposal_fun(m_current_params, m_previous_params, this);
 
         // Step 2: Using m_current_params, simulate data
-        TData data_i = simulation_fun(m_current_params, this);
+        TData data_i = m_simulation_fun(m_current_params, this);
 
         // Are we storing the data?
         if (sampled_data != nullptr)
             sampled_data->operator[](i) = data_i;
 
         // Step 3: Generate the summary statistics of the data
-        summary_fun(proposed_stats_i, data_i, this);
+        m_summary_fun(proposed_stats_i, data_i, this);
 
         // Step 4: Compute the hastings ratio using the kernel function
-        epiworld_double hr = kernel_fun(
+        epiworld_double hr = m_kernel_fun(
             proposed_stats_i, m_observed_stats, m_epsilon, this
             );
 

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1178,7 +1178,7 @@ class LFMCMC {
 private:
 
     // Random number sampling
-    std::shared_ptr< std::mt19937 > engine = nullptr;
+    std::shared_ptr< std::mt19937 > m_engine = nullptr;
     
     std::shared_ptr< std::uniform_real_distribution<> > runifd =
         std::make_shared< std::uniform_real_distribution<> >(0.0, 1.0);
@@ -1244,7 +1244,6 @@ private:
         bool print
     ) const;
 
-    // start_chrono, end_chrono (??)
     void chrono_start();
     void chrono_end();
     
@@ -1465,7 +1464,7 @@ class LFMCMC {
 private:
 
     // Random number sampling
-    std::shared_ptr< std::mt19937 > engine = nullptr;
+    std::shared_ptr< std::mt19937 > m_engine = nullptr;
     
     std::shared_ptr< std::uniform_real_distribution<> > runifd =
         std::make_shared< std::uniform_real_distribution<> >(0.0, 1.0);
@@ -1531,7 +1530,6 @@ private:
         bool print
     ) const;
 
-    // start_chrono, end_chrono (??)
     void chrono_start();
     void chrono_end();
     
@@ -1938,7 +1936,7 @@ inline void LFMCMC<TData>::run(
 template<typename TData>
 inline epiworld_double LFMCMC<TData>::runif()
 {
-    return runifd->operator()(*engine);
+    return runifd->operator()(*m_engine);
 }
 
 template<typename TData>
@@ -1947,13 +1945,13 @@ inline epiworld_double LFMCMC<TData>::runif(
     epiworld_double ub
 )
 {
-    return runifd->operator()(*engine) * (ub - lb) + lb;
+    return runifd->operator()(*m_engine) * (ub - lb) + lb;
 }
 
 template<typename TData>
 inline epiworld_double LFMCMC<TData>::rnorm()
 {
-    return rnormd->operator()(*engine);
+    return rnormd->operator()(*m_engine);
 }
 
 template<typename TData>
@@ -1962,13 +1960,13 @@ inline epiworld_double LFMCMC<TData>::rnorm(
     epiworld_double sd
     )
 {
-    return (rnormd->operator()(*engine)) * sd + mean;
+    return (rnormd->operator()(*m_engine)) * sd + mean;
 }
 
 template<typename TData>
 inline epiworld_double LFMCMC<TData>::rgamma()
 {
-    return rgammad->operator()(*engine);
+    return rgammad->operator()(*m_engine);
 }
 
 template<typename TData>
@@ -1982,7 +1980,7 @@ inline epiworld_double LFMCMC<TData>::rgamma(
 
     rgammad->param(std::gamma_distribution<>::param_type(alpha, beta));
 
-    epiworld_double ans = rgammad->operator()(*engine);
+    epiworld_double ans = rgammad->operator()(*m_engine);
 
     rgammad->param(old_param);
 
@@ -1993,14 +1991,14 @@ inline epiworld_double LFMCMC<TData>::rgamma(
 template<typename TData>
 inline void LFMCMC<TData>::seed(epiworld_fast_uint s) {
 
-    this->engine->seed(s);
+    this->m_engine->seed(s);
 
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_rand_engine(std::shared_ptr< std::mt19937 > & eng)
 {
-    engine = eng;
+    m_engine = eng;
 }
 
 template<typename TData>
@@ -2012,7 +2010,7 @@ inline void LFMCMC<TData>::set_rand_gamma(epiworld_double alpha, epiworld_double
 template<typename TData>
 inline std::shared_ptr< std::mt19937 > & LFMCMC<TData>::get_rand_endgine()
 {
-    return engine;
+    return m_engine;
 }
 
 // Step 1: Simulate data

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1267,8 +1267,8 @@ public:
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
     void set_kernel_fun(LFMCMCKernelFun<TData> fun);
 
-    void set_param_names(std::vector< std::string > names);
-    void set_stat_names(std::vector< std::string > names);
+    void set_params_names(std::vector< std::string > names);
+    void set_stats_names(std::vector< std::string > names);
     
     /**
      * @name Random number generation
@@ -1558,8 +1558,8 @@ public:
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
     void set_kernel_fun(LFMCMCKernelFun<TData> fun);
 
-    void set_param_names(std::vector< std::string > names);
-    void set_stat_names(std::vector< std::string > names);
+    void set_params_names(std::vector< std::string > names);
+    void set_stats_names(std::vector< std::string > names);
     
     /**
      * @name Random number generation
@@ -2359,7 +2359,7 @@ inline void LFMCMC<TData>::chrono_end() {
 }
 
 template<typename TData>
-inline void LFMCMC<TData>::set_param_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_params_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_params)
@@ -2369,7 +2369,7 @@ inline void LFMCMC<TData>::set_param_names(std::vector< std::string > names)
 
 }
 template<typename TData>
-inline void LFMCMC<TData>::set_stat_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_stats)

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1191,7 +1191,8 @@ private:
 
     // Process data
     TData m_observed_data;
-    
+    std::vector< TData > * m_simulated_data = nullptr;
+
     // Information about the size of the process
     size_t m_n_samples;
     size_t m_n_stats;
@@ -1205,18 +1206,15 @@ private:
 
     std::vector< epiworld_double > m_observed_stats;            ///< Observed statistics
 
-    std::vector< epiworld_double > m_param_samples;             ///< Sampled parameters
-    std::vector< epiworld_double > m_stat_samples;              ///< Sampled statistics
+    std::vector< epiworld_double > m_sample_params;             ///< Parameter samples
+    std::vector< epiworld_double > m_sample_stats;              ///< Statistic samples
     std::vector< bool >            m_sample_acceptance;         ///< Indicator if sample was accepted
+    std::vector< epiworld_double > m_sample_drawn_prob;         ///< Drawn probabilities (runif()) for each sample
     std::vector< epiworld_double > m_sample_kernel_scores;      ///< Kernel scores for each sample
 
     std::vector< epiworld_double > m_accepted_params;           ///< Posterior distribution of parameters from accepted samples
     std::vector< epiworld_double > m_accepted_stats;            ///< Posterior distribution of statistics from accepted samples
     std::vector< epiworld_double > m_accepted_kernel_scores;    ///< Kernel scores for each accepted sample
-
-    // No change
-    std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
-    std::vector< TData > * sampled_data = nullptr;
 
     // Functions
     LFMCMCSimFun<TData> m_simulation_fun;
@@ -1258,11 +1256,16 @@ public:
     LFMCMC(const TData & observed_data_) : m_observed_data(observed_data_) {};
     ~LFMCMC() {};
 
+    // Setting LFMCMC variables
     void set_observed_data(const TData & observed_data_) {m_observed_data = observed_data_;};
+    
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
     void set_kernel_fun(LFMCMCKernelFun<TData> fun);
+
+    void set_param_names(std::vector< std::string > names);
+    void set_stat_names(std::vector< std::string > names);
     
     /**
      * @name Random number generation
@@ -1294,24 +1297,22 @@ public:
 
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
 
-    const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
-    const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
+    const std::vector< epiworld_double > & get_sample_params() {return m_sample_params;};
+    const std::vector< epiworld_double > & get_sample_stats() {return m_sample_stats;};
     const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
+    const std::vector< epiworld_double > & get_sample_drawn_prob() {return m_sample_drawn_prob;};
     const std::vector< epiworld_double > & get_sample_kernel_scores() {return m_sample_kernel_scores;};
 
     const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
     const std::vector< epiworld_double > & get_accepted_kernel_scores() {return m_accepted_kernel_scores;};
     
-    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
-    std::vector< TData > * get_sampled_data() {return sampled_data;};
-
-    void set_param_names(std::vector< std::string > names);
-    void set_stat_names(std::vector< std::string > names);
+    std::vector< TData > * get_simulated_data() {return m_simulated_data;};
 
     std::vector< epiworld_double > get_mean_params();
     std::vector< epiworld_double > get_mean_stats();
 
+    // Printing
     void print(size_t burnin = 0u) const;
 
 };
@@ -1478,7 +1479,8 @@ private:
 
     // Process data
     TData m_observed_data;
-    
+    std::vector< TData > * m_simulated_data = nullptr;
+
     // Information about the size of the process
     size_t m_n_samples;
     size_t m_n_stats;
@@ -1492,18 +1494,15 @@ private:
 
     std::vector< epiworld_double > m_observed_stats;            ///< Observed statistics
 
-    std::vector< epiworld_double > m_param_samples;             ///< Sampled parameters
-    std::vector< epiworld_double > m_stat_samples;              ///< Sampled statistics
+    std::vector< epiworld_double > m_sample_params;             ///< Parameter samples
+    std::vector< epiworld_double > m_sample_stats;              ///< Statistic samples
     std::vector< bool >            m_sample_acceptance;         ///< Indicator if sample was accepted
+    std::vector< epiworld_double > m_sample_drawn_prob;         ///< Drawn probabilities (runif()) for each sample
     std::vector< epiworld_double > m_sample_kernel_scores;      ///< Kernel scores for each sample
 
     std::vector< epiworld_double > m_accepted_params;           ///< Posterior distribution of parameters from accepted samples
     std::vector< epiworld_double > m_accepted_stats;            ///< Posterior distribution of statistics from accepted samples
     std::vector< epiworld_double > m_accepted_kernel_scores;    ///< Kernel scores for each accepted sample
-
-    // No change
-    std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
-    std::vector< TData > * sampled_data = nullptr;
 
     // Functions
     LFMCMCSimFun<TData> m_simulation_fun;
@@ -1545,11 +1544,16 @@ public:
     LFMCMC(const TData & observed_data_) : m_observed_data(observed_data_) {};
     ~LFMCMC() {};
 
+    // Setting LFMCMC variables
     void set_observed_data(const TData & observed_data_) {m_observed_data = observed_data_;};
+    
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
     void set_kernel_fun(LFMCMCKernelFun<TData> fun);
+
+    void set_param_names(std::vector< std::string > names);
+    void set_stat_names(std::vector< std::string > names);
     
     /**
      * @name Random number generation
@@ -1581,24 +1585,22 @@ public:
 
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
 
-    const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
-    const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
+    const std::vector< epiworld_double > & get_sample_params() {return m_sample_params;};
+    const std::vector< epiworld_double > & get_sample_stats() {return m_sample_stats;};
     const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
+    const std::vector< epiworld_double > & get_sample_drawn_prob() {return m_sample_drawn_prob;};
     const std::vector< epiworld_double > & get_sample_kernel_scores() {return m_sample_kernel_scores;};
 
     const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
     const std::vector< epiworld_double > & get_accepted_kernel_scores() {return m_accepted_kernel_scores;};
     
-    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
-    std::vector< TData > * get_sampled_data() {return sampled_data;};
-
-    void set_param_names(std::vector< std::string > names);
-    void set_stat_names(std::vector< std::string > names);
+    std::vector< TData > * get_simulated_data() {return m_simulated_data;};
 
     std::vector< epiworld_double > get_mean_params();
     std::vector< epiworld_double > get_mean_stats();
 
+    // Printing
     void print(size_t burnin = 0u) const;
 
 };
@@ -1836,8 +1838,8 @@ inline void LFMCMC<TData>::run(
     m_current_params.resize(m_n_params);
     m_previous_params.resize(m_n_params);
 
-    if (sampled_data != nullptr)
-        sampled_data->resize(m_n_samples);
+    if (m_simulated_data != nullptr)
+        m_simulated_data->resize(m_n_samples);
 
     m_previous_params = m_initial_params;
     m_current_params  = m_initial_params;
@@ -1847,9 +1849,9 @@ inline void LFMCMC<TData>::run(
     m_n_stats = m_observed_stats.size();
 
     // Reserving size
-    drawn_prob.resize(m_n_samples);
+    m_sample_drawn_prob.resize(m_n_samples);
     m_sample_acceptance.resize(m_n_samples, false);
-    m_stat_samples.resize(m_n_samples * m_n_stats);
+    m_sample_stats.resize(m_n_samples * m_n_stats);
     m_sample_kernel_scores.resize(m_n_samples);
 
     m_accepted_params.resize(m_n_samples * m_n_params);
@@ -1866,7 +1868,7 @@ inline void LFMCMC<TData>::run(
 
     // Recording statistics
     for (size_t i = 0u; i < m_n_stats; ++i)
-        m_stat_samples[i] = proposed_stats_i[i];
+        m_sample_stats[i] = proposed_stats_i[i];
 
     for (size_t k = 0u; k < m_n_params; ++k)
         m_accepted_params[k] = m_initial_params[k];
@@ -1880,8 +1882,8 @@ inline void LFMCMC<TData>::run(
         TData data_i = m_simulation_fun(m_current_params, this);
 
         // Are we storing the data?
-        if (sampled_data != nullptr)
-            sampled_data->operator[](i) = data_i;
+        if (m_simulated_data != nullptr)
+            m_simulated_data->operator[](i) = data_i;
 
         // Step 3: Generate the summary statistics of the data
         m_summary_fun(proposed_stats_i, data_i, this);
@@ -1895,11 +1897,11 @@ inline void LFMCMC<TData>::run(
 
         // Storing data
         for (size_t k = 0u; k < m_n_stats; ++k)
-            m_stat_samples[i * m_n_stats + k] = proposed_stats_i[k];
+            m_sample_stats[i * m_n_stats + k] = proposed_stats_i[k];
         
         // Running Hastings ratio
         epiworld_double r = runif();
-        drawn_prob[i] = r;
+        m_sample_drawn_prob[i] = r;
 
         // Step 5: Update if likely
         if (r < std::min(static_cast<epiworld_double>(1.0), hr / m_accepted_kernel_scores[i - 1u]))

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -1085,15 +1085,15 @@ using LFMCMCKernelFun = std::function<epiworld_double(const std::vector< epiworl
 
 /**
  * @brief Proposal function
- * @param params_now Vector where to save the new parameters.
- * @param params_prev Vector of reference parameters.
+ * @param new_params Vector where to save the new parameters.
+ * @param old_params Vector of reference parameters.
  * @param m LFMCMC model.
  * @tparam TData 
  */
 template<typename TData>
 inline void proposal_fun_normal(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 );
 
@@ -1122,15 +1122,15 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
  * Proposals are made within a radious 1 of the current
  * state of the parameters.
  * 
- * @param params_now Where to write the new parameters
- * @param params_prev Reference parameters
+ * @param new_params Where to write the new parameters
+ * @param old_params Reference parameters
  * @tparam TData 
  * @param m LFMCMC model.
  */
 template<typename TData>
 inline void proposal_fun_unif(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 );
 
@@ -1192,24 +1192,18 @@ private:
     // Process data
     TData m_observed_data;
     
-    // Information about the size of the problem
+    // Information about the size of the process
     size_t m_n_samples;
     size_t m_n_stats;
     size_t m_n_params;
 
     epiworld_double m_epsilon;
 
-    // params_new/new_params current_params (new_params in proposal function)
-    std::vector< epiworld_double > params_now;
-    // params_prev/prev_params maybe params_old/old_params
-    // previous_params
-    std::vector< epiworld_double > params_prev;
-    // params_init (no change)
-    // initial_params
-    std::vector< epiworld_double > params_init;
+    std::vector< epiworld_double > m_current_params;
+    std::vector< epiworld_double > m_previous_params;
+    std::vector< epiworld_double > m_initial_params;
 
-    // observed_stats (no change)
-    std::vector< epiworld_double > observed_stats; ///< Observed statistics
+    std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
 
     // param_samples, stat_samples
     std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
@@ -1304,10 +1298,10 @@ public:
     size_t get_n_params() const {return m_n_params;};
     epiworld_double get_epsilon() const {return m_epsilon;};
 
-    const std::vector< epiworld_double > & get_params_now() {return params_now;};
-    const std::vector< epiworld_double > & get_params_prev() {return params_prev;};
-    const std::vector< epiworld_double > & get_params_init() {return params_init;};
-    const std::vector< epiworld_double > & get_statistics_obs() {return observed_stats;};
+    const std::vector< epiworld_double > & get_current_params() {return m_current_params;};
+    const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
+    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
+    const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
     const std::vector< epiworld_double > & get_statistics_hist() {return sampled_stats;};
     const std::vector< bool >            & get_statistics_accepted() {return sampled_accepted;};
     const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
@@ -1385,15 +1379,15 @@ using LFMCMCKernelFun = std::function<epiworld_double(const std::vector< epiworl
 
 /**
  * @brief Proposal function
- * @param params_now Vector where to save the new parameters.
- * @param params_prev Vector of reference parameters.
+ * @param new_params Vector where to save the new parameters.
+ * @param old_params Vector of reference parameters.
  * @param m LFMCMC model.
  * @tparam TData 
  */
 template<typename TData>
 inline void proposal_fun_normal(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 );
 
@@ -1422,15 +1416,15 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
  * Proposals are made within a radious 1 of the current
  * state of the parameters.
  * 
- * @param params_now Where to write the new parameters
- * @param params_prev Reference parameters
+ * @param new_params Where to write the new parameters
+ * @param old_params Reference parameters
  * @tparam TData 
  * @param m LFMCMC model.
  */
 template<typename TData>
 inline void proposal_fun_unif(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 );
 
@@ -1492,24 +1486,18 @@ private:
     // Process data
     TData m_observed_data;
     
-    // Information about the size of the problem
+    // Information about the size of the process
     size_t m_n_samples;
     size_t m_n_stats;
     size_t m_n_params;
 
     epiworld_double m_epsilon;
 
-    // params_new/new_params current_params (new_params in proposal function)
-    std::vector< epiworld_double > params_now;
-    // params_prev/prev_params maybe params_old/old_params
-    // previous_params
-    std::vector< epiworld_double > params_prev;
-    // params_init (no change)
-    // initial_params
-    std::vector< epiworld_double > params_init;
+    std::vector< epiworld_double > m_current_params;
+    std::vector< epiworld_double > m_previous_params;
+    std::vector< epiworld_double > m_initial_params;
 
-    // observed_stats (no change)
-    std::vector< epiworld_double > observed_stats; ///< Observed statistics
+    std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
 
     // param_samples, stat_samples
     std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
@@ -1604,10 +1592,10 @@ public:
     size_t get_n_params() const {return m_n_params;};
     epiworld_double get_epsilon() const {return m_epsilon;};
 
-    const std::vector< epiworld_double > & get_params_now() {return params_now;};
-    const std::vector< epiworld_double > & get_params_prev() {return params_prev;};
-    const std::vector< epiworld_double > & get_params_init() {return params_init;};
-    const std::vector< epiworld_double > & get_statistics_obs() {return observed_stats;};
+    const std::vector< epiworld_double > & get_current_params() {return m_current_params;};
+    const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
+    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
+    const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
     const std::vector< epiworld_double > & get_statistics_hist() {return sampled_stats;};
     const std::vector< bool >            & get_statistics_accepted() {return sampled_accepted;};
     const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
@@ -1642,20 +1630,20 @@ public:
 
 /**
  * @brief Proposal function
- * @param params_now Vector where to save the new parameters.
- * @param params_prev Vector of reference parameters.
+ * @param new_params Vector where to save the new parameters.
+ * @param old_params Vector of reference parameters.
  * @param m LFMCMC model.
  * @tparam TData 
  */
 template<typename TData>
 inline void proposal_fun_normal(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 ) {
 
     for (size_t p = 0u; p < m->get_n_params(); ++p)
-        params_now[p] = params_prev[p] + m->rnorm();
+        new_params[p] = old_params[p] + m->rnorm();
 
     return;
 }
@@ -1681,20 +1669,20 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
 
     LFMCMCProposalFun<TData> fun =
         [scale,lb,ub](
-            std::vector< epiworld_double >& params_now,
-            const std::vector< epiworld_double >& params_prev,
+            std::vector< epiworld_double >& new_params,
+            const std::vector< epiworld_double >& old_params,
             LFMCMC<TData>* m
         ) {
 
         // Making the proposal
         for (size_t p = 0u; p < m->get_n_params(); ++p)
-            params_now[p] = params_prev[p] + m->rnorm() * scale;
+            new_params[p] = old_params[p] + m->rnorm() * scale;
 
         // Checking boundaries
         epiworld_double d = ub - lb;
         int odd;
         epiworld_double d_above, d_below;
-        for (auto & p : params_now)
+        for (auto & p : new_params)
         {
 
             // Correcting if parameter goes above the upper bound
@@ -1721,7 +1709,7 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
         }
 
         #ifdef EPI_DEBUG
-        for (auto & p : params_now)
+        for (auto & p : new_params)
             if (p < lb || p > ub)
                 throw std::range_error("The parameter is out of bounds.");
         #endif
@@ -1740,20 +1728,20 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
  * Proposals are made within a radious 1 of the current
  * state of the parameters.
  * 
- * @param params_now Where to write the new parameters
- * @param params_prev Reference parameters
+ * @param new_params Where to write the new parameters
+ * @param old_params Reference parameters
  * @tparam TData 
  * @param m LFMCMC model.
  */
 template<typename TData>
 inline void proposal_fun_unif(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 ) {
 
     for (size_t p = 0u; p < m->get_n_params(); ++p)
-        params_now[p] = (params_prev[p] + m->runif(-1.0, 1.0));
+        new_params[p] = (old_params[p] + m->runif(-1.0, 1.0));
 
     return;
 }
@@ -1853,24 +1841,24 @@ inline void LFMCMC<TData>::run(
     // Setting the baseline parameters of the model
     m_n_samples    = n_samples_;
     m_epsilon      = epsilon_;
-    params_init  = params_init_;
+    m_initial_params  = params_init_;
     m_n_params = params_init_.size();
 
     if (seed >= 0)
         this->seed(seed);
 
-    params_now.resize(m_n_params);
-    params_prev.resize(m_n_params);
+    m_current_params.resize(m_n_params);
+    m_previous_params.resize(m_n_params);
 
     if (sampled_data != nullptr)
         sampled_data->resize(m_n_samples);
 
-    params_prev = params_init;
-    params_now  = params_init;
+    m_previous_params = m_initial_params;
+    m_current_params  = m_initial_params;
 
     // Computing the baseline sufficient statistics
-    summary_fun(observed_stats, m_observed_data, this);
-    m_n_stats = observed_stats.size();
+    summary_fun(m_observed_stats, m_observed_data, this);
+    m_n_stats = m_observed_stats.size();
 
     // Reserving size
     drawn_prob.resize(m_n_samples);
@@ -1882,12 +1870,12 @@ inline void LFMCMC<TData>::run(
     accepted_stats.resize(m_n_samples * m_n_stats);
     accepted_params_prob.resize(m_n_samples);
 
-    TData data_i = simulation_fun(params_init, this);
+    TData data_i = simulation_fun(m_initial_params, this);
 
     std::vector< epiworld_double > proposed_stats_i;
     summary_fun(proposed_stats_i, data_i, this);
     accepted_params_prob[0u] = kernel_fun(
-        proposed_stats_i, observed_stats, m_epsilon, this
+        proposed_stats_i, m_observed_stats, m_epsilon, this
         );
 
     // Recording statistics
@@ -1895,15 +1883,15 @@ inline void LFMCMC<TData>::run(
         sampled_stats[i] = proposed_stats_i[i];
 
     for (size_t k = 0u; k < m_n_params; ++k)
-        accepted_params[k] = params_init[k];
+        accepted_params[k] = m_initial_params[k];
    
     for (size_t i = 1u; i < m_n_samples; ++i)
     {
-        // Step 1: Generate a proposal and store it in params_now
-        proposal_fun(params_now, params_prev, this);
+        // Step 1: Generate a proposal and store it in m_current_params
+        proposal_fun(m_current_params, m_previous_params, this);
 
-        // Step 2: Using params_now, simulate data
-        TData data_i = simulation_fun(params_now, this);
+        // Step 2: Using m_current_params, simulate data
+        TData data_i = simulation_fun(m_current_params, this);
 
         // Are we storing the data?
         if (sampled_data != nullptr)
@@ -1914,7 +1902,7 @@ inline void LFMCMC<TData>::run(
 
         // Step 4: Compute the hastings ratio using the kernel function
         epiworld_double hr = kernel_fun(
-            proposed_stats_i, observed_stats, m_epsilon, this
+            proposed_stats_i, m_observed_stats, m_epsilon, this
             );
 
         sampled_stats_prob[i] = hr;
@@ -1937,7 +1925,7 @@ inline void LFMCMC<TData>::run(
                 accepted_stats[i * m_n_stats + k] =
                     proposed_stats_i[k];
 
-            params_prev = params_now;
+            m_previous_params = m_current_params;
 
         } else
         {
@@ -1951,7 +1939,7 @@ inline void LFMCMC<TData>::run(
             
 
         for (size_t k = 0u; k < m_n_params; ++k)
-            accepted_params[i * m_n_params + k] = params_prev[k];
+            accepted_params[i * m_n_params + k] = m_previous_params[k];
 
     }
 
@@ -2248,7 +2236,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_params[k * 3],
                 summ_params[k * 3 + 1u],
                 summ_params[k * 3 + 2u],
-                params_init[k]
+                m_initial_params[k]
                 );
         }
 
@@ -2270,7 +2258,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_params[k * 3],
                 summ_params[k * 3 + 1u],
                 summ_params[k * 3 + 2u],
-                params_init[k]
+                m_initial_params[k]
                 );
         }
 
@@ -2320,7 +2308,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_stats[k * 3],
                 summ_stats[k * 3 + 1u],
                 summ_stats[k * 3 + 2u],
-                observed_stats[k]
+                m_observed_stats[k]
                 );
         }
 
@@ -2342,7 +2330,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_stats[k * 3],
                 summ_stats[k * 3 + 1u],
                 summ_stats[k * 3 + 2u],
-                observed_stats[k]
+                m_observed_stats[k]
                 );
         }
 

--- a/examples/10-likelihood-free-mcmc/main.cpp
+++ b/examples/10-likelihood-free-mcmc/main.cpp
@@ -87,8 +87,8 @@ int main()
 
     lfmcmc.run(par0, 2000, 1);
     
-    lfmcmc.set_param_names({"Immune recovery", "Infectiousness"});
-    lfmcmc.set_stat_names(model.get_states());
+    lfmcmc.set_params_names({"Immune recovery", "Infectiousness"});
+    lfmcmc.set_stats_names(model.get_states());
 
     lfmcmc.print();
 

--- a/examples/10-likelihood-free-mcmc/main.cpp
+++ b/examples/10-likelihood-free-mcmc/main.cpp
@@ -87,8 +87,8 @@ int main()
 
     lfmcmc.run(par0, 2000, 1);
     
-    lfmcmc.set_par_names({"Immune recovery", "Infectiousness"});
-    lfmcmc.set_stats_names(model.get_states());
+    lfmcmc.set_param_names({"Immune recovery", "Infectiousness"});
+    lfmcmc.set_stat_names(model.get_states());
 
     lfmcmc.print();
 

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -18,7 +18,7 @@
 
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
-#define EPIWORLD_VERSION_MINOR 5
+#define EPIWORLD_VERSION_MINOR 6
 #define EPIWORLD_VERSION_PATCH 0
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -205,8 +205,8 @@ public:
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
     void set_kernel_fun(LFMCMCKernelFun<TData> fun);
 
-    void set_param_names(std::vector< std::string > names);
-    void set_stat_names(std::vector< std::string > names);
+    void set_params_names(std::vector< std::string > names);
+    void set_stats_names(std::vector< std::string > names);
     
     /**
      * @name Random number generation

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -129,7 +129,8 @@ private:
 
     // Process data
     TData m_observed_data;
-    
+    std::vector< TData > * m_simulated_data = nullptr;
+
     // Information about the size of the process
     size_t m_n_samples;
     size_t m_n_stats;
@@ -143,18 +144,15 @@ private:
 
     std::vector< epiworld_double > m_observed_stats;            ///< Observed statistics
 
-    std::vector< epiworld_double > m_param_samples;             ///< Sampled parameters
-    std::vector< epiworld_double > m_stat_samples;              ///< Sampled statistics
+    std::vector< epiworld_double > m_sample_params;             ///< Parameter samples
+    std::vector< epiworld_double > m_sample_stats;              ///< Statistic samples
     std::vector< bool >            m_sample_acceptance;         ///< Indicator if sample was accepted
+    std::vector< epiworld_double > m_sample_drawn_prob;         ///< Drawn probabilities (runif()) for each sample
     std::vector< epiworld_double > m_sample_kernel_scores;      ///< Kernel scores for each sample
 
     std::vector< epiworld_double > m_accepted_params;           ///< Posterior distribution of parameters from accepted samples
     std::vector< epiworld_double > m_accepted_stats;            ///< Posterior distribution of statistics from accepted samples
     std::vector< epiworld_double > m_accepted_kernel_scores;    ///< Kernel scores for each accepted sample
-
-    // No change
-    std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
-    std::vector< TData > * sampled_data = nullptr;
 
     // Functions
     LFMCMCSimFun<TData> m_simulation_fun;
@@ -196,11 +194,16 @@ public:
     LFMCMC(const TData & observed_data_) : m_observed_data(observed_data_) {};
     ~LFMCMC() {};
 
+    // Setting LFMCMC variables
     void set_observed_data(const TData & observed_data_) {m_observed_data = observed_data_;};
+    
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
     void set_kernel_fun(LFMCMCKernelFun<TData> fun);
+
+    void set_param_names(std::vector< std::string > names);
+    void set_stat_names(std::vector< std::string > names);
     
     /**
      * @name Random number generation
@@ -232,24 +235,22 @@ public:
 
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
 
-    const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
-    const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
+    const std::vector< epiworld_double > & get_sample_params() {return m_sample_params;};
+    const std::vector< epiworld_double > & get_sample_stats() {return m_sample_stats;};
     const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
+    const std::vector< epiworld_double > & get_sample_drawn_prob() {return m_sample_drawn_prob;};
     const std::vector< epiworld_double > & get_sample_kernel_scores() {return m_sample_kernel_scores;};
 
     const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
     const std::vector< epiworld_double > & get_accepted_kernel_scores() {return m_accepted_kernel_scores;};
     
-    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
-    std::vector< TData > * get_sampled_data() {return sampled_data;};
-
-    void set_param_names(std::vector< std::string > names);
-    void set_stat_names(std::vector< std::string > names);
+    std::vector< TData > * get_simulated_data() {return m_simulated_data;};
 
     std::vector< epiworld_double > get_mean_params();
     std::vector< epiworld_double > get_mean_stats();
 
+    // Printing
     void print(size_t burnin = 0u) const;
 
 };

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -143,17 +143,14 @@ private:
 
     std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
 
-    // param_samples, stat_samples
-    std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
-    std::vector< epiworld_double > sampled_stats;      ///< Sampled statistics
+    std::vector< epiworld_double > m_param_samples;     ///< Sampled Parameters
+    std::vector< epiworld_double > m_stat_samples;      ///< Sampled statistics
     // What is this?
     std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
-    // accepted_samples
-    std::vector< bool >            sampled_accepted;   ///< Indicator of accepted statistics
+    std::vector< bool >            m_sample_acceptance;   ///< Indicator of accepted statistics
 
-    // accepted_params, accepted_stats
-    std::vector< epiworld_double > accepted_params;      ///< Posterior distribution (accepted samples)
-    std::vector< epiworld_double > accepted_stats;       ///< Posterior distribution (accepted samples)
+    std::vector< epiworld_double > m_accepted_params;      ///< Posterior distribution (accepted samples)
+    std::vector< epiworld_double > m_accepted_stats;       ///< Posterior distribution (accepted samples)
     // What is this?
     std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
 
@@ -171,17 +168,14 @@ private:
     std::vector< std::string > m_param_names;
     std::vector< std::string > m_stat_names;
 
-    // start_time, end_time (??)
-    std::chrono::time_point<std::chrono::steady_clock> time_start;
-    std::chrono::time_point<std::chrono::steady_clock> time_end;
+    std::chrono::time_point<std::chrono::steady_clock> m_start_time;
+    std::chrono::time_point<std::chrono::steady_clock> m_end_time;
 
     // std::chrono::milliseconds
-    // elapsed_time
-    std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
+    std::chrono::duration<epiworld_double,std::micro> m_elapsed_time = 
         std::chrono::duration<epiworld_double,std::micro>::zero();
 
-    // get_elapsed_time
-    inline void get_elapsed(
+    inline void get_elapsed_time(
         std::string unit,
         epiworld_double * last_elapsed,
         std::string * unit_abbr,
@@ -239,14 +233,16 @@ public:
     const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
     const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
-    const std::vector< epiworld_double > & get_statistics_hist() {return sampled_stats;};
-    const std::vector< bool >            & get_statistics_accepted() {return sampled_accepted;};
+
+    const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
+    const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
+    const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
     const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
     const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
     std::vector< TData > * get_sampled_data() {return sampled_data;};
 
-    const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
-    const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
+    const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
+    const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
 
     void set_param_names(std::vector< std::string > names);
     void set_stat_names(std::vector< std::string > names);

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -159,10 +159,10 @@ private:
     std::vector< TData > * sampled_data = nullptr;
 
     // Functions
-    LFMCMCSimFun<TData> simulation_fun;
-    LFMCMCSummaryFun<TData> summary_fun;
-    LFMCMCProposalFun<TData> proposal_fun = proposal_fun_normal<TData>;
-    LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
+    LFMCMCSimFun<TData> m_simulation_fun;
+    LFMCMCSummaryFun<TData> m_summary_fun;
+    LFMCMCProposalFun<TData> m_proposal_fun = proposal_fun_normal<TData>;
+    LFMCMCKernelFun<TData> m_kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
     std::vector< std::string > m_param_names;

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -23,15 +23,15 @@ using LFMCMCKernelFun = std::function<epiworld_double(const std::vector< epiworl
 
 /**
  * @brief Proposal function
- * @param params_now Vector where to save the new parameters.
- * @param params_prev Vector of reference parameters.
+ * @param new_params Vector where to save the new parameters.
+ * @param old_params Vector of reference parameters.
  * @param m LFMCMC model.
  * @tparam TData 
  */
 template<typename TData>
 inline void proposal_fun_normal(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 );
 
@@ -60,15 +60,15 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
  * Proposals are made within a radious 1 of the current
  * state of the parameters.
  * 
- * @param params_now Where to write the new parameters
- * @param params_prev Reference parameters
+ * @param new_params Where to write the new parameters
+ * @param old_params Reference parameters
  * @tparam TData 
  * @param m LFMCMC model.
  */
 template<typename TData>
 inline void proposal_fun_unif(
-    std::vector< epiworld_double >& params_now,
-    const std::vector< epiworld_double >& params_prev,
+    std::vector< epiworld_double >& new_params,
+    const std::vector< epiworld_double >& old_params,
     LFMCMC<TData>* m
 );
 
@@ -130,24 +130,18 @@ private:
     // Process data
     TData m_observed_data;
     
-    // Information about the size of the problem
+    // Information about the size of the process
     size_t m_n_samples;
     size_t m_n_stats;
     size_t m_n_params;
 
     epiworld_double m_epsilon;
 
-    // params_new/new_params current_params (new_params in proposal function)
-    std::vector< epiworld_double > params_now;
-    // params_prev/prev_params maybe params_old/old_params
-    // previous_params
-    std::vector< epiworld_double > params_prev;
-    // params_init (no change)
-    // initial_params
-    std::vector< epiworld_double > params_init;
+    std::vector< epiworld_double > m_current_params;
+    std::vector< epiworld_double > m_previous_params;
+    std::vector< epiworld_double > m_initial_params;
 
-    // observed_stats (no change)
-    std::vector< epiworld_double > observed_stats; ///< Observed statistics
+    std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
 
     // param_samples, stat_samples
     std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
@@ -242,10 +236,10 @@ public:
     size_t get_n_params() const {return m_n_params;};
     epiworld_double get_epsilon() const {return m_epsilon;};
 
-    const std::vector< epiworld_double > & get_params_now() {return params_now;};
-    const std::vector< epiworld_double > & get_params_prev() {return params_prev;};
-    const std::vector< epiworld_double > & get_params_init() {return params_init;};
-    const std::vector< epiworld_double > & get_statistics_obs() {return observed_stats;};
+    const std::vector< epiworld_double > & get_current_params() {return m_current_params;};
+    const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
+    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
+    const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
     const std::vector< epiworld_double > & get_statistics_hist() {return sampled_stats;};
     const std::vector< bool >            & get_statistics_accepted() {return sampled_accepted;};
     const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -137,22 +137,20 @@ private:
 
     epiworld_double m_epsilon;
 
-    std::vector< epiworld_double > m_current_params;
-    std::vector< epiworld_double > m_previous_params;
-    std::vector< epiworld_double > m_initial_params;
+    std::vector< epiworld_double > m_initial_params;            ///< Initial parameters
+    std::vector< epiworld_double > m_current_params;            ///< Parameters for the current sample
+    std::vector< epiworld_double > m_previous_params;           ///< Parameters from the previous sample
 
-    std::vector< epiworld_double > m_observed_stats; ///< Observed statistics
+    std::vector< epiworld_double > m_observed_stats;            ///< Observed statistics
 
-    std::vector< epiworld_double > m_param_samples;     ///< Sampled Parameters
-    std::vector< epiworld_double > m_stat_samples;      ///< Sampled statistics
-    // What is this?
-    std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
-    std::vector< bool >            m_sample_acceptance;   ///< Indicator of accepted statistics
+    std::vector< epiworld_double > m_param_samples;             ///< Sampled parameters
+    std::vector< epiworld_double > m_stat_samples;              ///< Sampled statistics
+    std::vector< bool >            m_sample_acceptance;         ///< Indicator if sample was accepted
+    std::vector< epiworld_double > m_sample_kernel_scores;      ///< Kernel scores for each sample
 
-    std::vector< epiworld_double > m_accepted_params;      ///< Posterior distribution (accepted samples)
-    std::vector< epiworld_double > m_accepted_stats;       ///< Posterior distribution (accepted samples)
-    // What is this?
-    std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
+    std::vector< epiworld_double > m_accepted_params;           ///< Posterior distribution of parameters from accepted samples
+    std::vector< epiworld_double > m_accepted_stats;            ///< Posterior distribution of statistics from accepted samples
+    std::vector< epiworld_double > m_accepted_kernel_scores;    ///< Kernel scores for each accepted sample
 
     // No change
     std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
@@ -188,7 +186,7 @@ private:
 public:
 
     void run(
-        std::vector< epiworld_double > param_init,
+        std::vector< epiworld_double > params_init_,
         size_t n_samples_,
         epiworld_double epsilon_,
         int seed = -1
@@ -228,20 +226,23 @@ public:
     size_t get_n_params() const {return m_n_params;};
     epiworld_double get_epsilon() const {return m_epsilon;};
 
+    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
     const std::vector< epiworld_double > & get_current_params() {return m_current_params;};
     const std::vector< epiworld_double > & get_previous_params() {return m_previous_params;};
-    const std::vector< epiworld_double > & get_initial_params() {return m_initial_params;};
+
     const std::vector< epiworld_double > & get_observed_stats() {return m_observed_stats;};
 
     const std::vector< epiworld_double > & get_param_samples() {return m_param_samples;};
     const std::vector< epiworld_double > & get_stat_samples() {return m_stat_samples;};
     const std::vector< bool >            & get_sample_acceptance() {return m_sample_acceptance;};
-    const std::vector< epiworld_double > & get_posterior_lf_prob() {return accepted_params_prob;};
-    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
-    std::vector< TData > * get_sampled_data() {return sampled_data;};
+    const std::vector< epiworld_double > & get_sample_kernel_scores() {return m_sample_kernel_scores;};
 
     const std::vector< epiworld_double > & get_accepted_params() {return m_accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return m_accepted_stats;};
+    const std::vector< epiworld_double > & get_accepted_kernel_scores() {return m_accepted_kernel_scores;};
+    
+    const std::vector< epiworld_double > & get_drawn_prob() {return drawn_prob;};
+    std::vector< TData > * get_sampled_data() {return sampled_data;};
 
     void set_param_names(std::vector< std::string > names);
     void set_stat_names(std::vector< std::string > names);

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -168,9 +168,8 @@ private:
     LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
-    // param_names, stat_names
-    std::vector< std::string > names_parameters;
-    std::vector< std::string > names_statistics;
+    std::vector< std::string > m_param_names;
+    std::vector< std::string > m_stat_names;
 
     // start_time, end_time (??)
     std::chrono::time_point<std::chrono::steady_clock> time_start;
@@ -249,13 +248,11 @@ public:
     const std::vector< epiworld_double > & get_accepted_params() {return accepted_params;};
     const std::vector< epiworld_double > & get_accepted_stats() {return accepted_stats;};
 
+    void set_param_names(std::vector< std::string > names);
+    void set_stat_names(std::vector< std::string > names);
 
-    void set_par_names(std::vector< std::string > names);
-    void set_stats_names(std::vector< std::string > names);
-
-    // get_mean_params, get_mean_stats
-    std::vector< epiworld_double > get_params_mean();
-    std::vector< epiworld_double > get_stats_mean();
+    std::vector< epiworld_double > get_mean_params();
+    std::vector< epiworld_double > get_mean_stats();
 
     void print(size_t burnin = 0u) const;
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -75,17 +75,17 @@ inline void proposal_fun_unif(
 /**
  * @brief Uses the uniform kernel with euclidean distance
  * 
- * @param stats_now Vector of current statistics based on 
- * simulated data.
- * @param stats_obs Vector of observed statistics
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
  * @param epsilon Epsilon parameter
- * @param m LFMCMC model.
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_uniform(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 );
@@ -94,14 +94,17 @@ inline epiworld_double kernel_fun_uniform(
  * @brief Gaussian kernel
  * 
  * @tparam TData 
- * @param epsilon 
- * @param m 
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
+ * @param epsilon Epsilon parameter
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_gaussian(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 );

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -116,7 +116,7 @@ class LFMCMC {
 private:
 
     // Random number sampling
-    std::shared_ptr< std::mt19937 > engine = nullptr;
+    std::shared_ptr< std::mt19937 > m_engine = nullptr;
     
     std::shared_ptr< std::uniform_real_distribution<> > runifd =
         std::make_shared< std::uniform_real_distribution<> >(0.0, 1.0);
@@ -182,7 +182,6 @@ private:
         bool print
     ) const;
 
-    // start_chrono, end_chrono (??)
     void chrono_start();
     void chrono_end();
     

--- a/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-bones.hpp
@@ -128,30 +128,42 @@ private:
         std::make_shared< std::gamma_distribution<> >();
 
     // Process data
-    TData observed_data;
+    TData m_observed_data;
     
     // Information about the size of the problem
-    size_t n_samples;
-    size_t n_statistics;
-    size_t n_parameters;
+    size_t m_n_samples;
+    size_t m_n_stats;
+    size_t m_n_params;
 
-    epiworld_double epsilon;
+    epiworld_double m_epsilon;
 
+    // params_new/new_params current_params (new_params in proposal function)
     std::vector< epiworld_double > params_now;
+    // params_prev/prev_params maybe params_old/old_params
+    // previous_params
     std::vector< epiworld_double > params_prev;
+    // params_init (no change)
+    // initial_params
     std::vector< epiworld_double > params_init;
 
+    // observed_stats (no change)
     std::vector< epiworld_double > observed_stats; ///< Observed statistics
 
+    // param_samples, stat_samples
     std::vector< epiworld_double > sampled_params;     ///< Sampled Parameters
     std::vector< epiworld_double > sampled_stats;      ///< Sampled statistics
+    // What is this?
     std::vector< epiworld_double > sampled_stats_prob; ///< Sampled statistics
+    // accepted_samples
     std::vector< bool >            sampled_accepted;   ///< Indicator of accepted statistics
 
+    // accepted_params, accepted_stats
     std::vector< epiworld_double > accepted_params;      ///< Posterior distribution (accepted samples)
     std::vector< epiworld_double > accepted_stats;       ///< Posterior distribution (accepted samples)
+    // What is this?
     std::vector< epiworld_double > accepted_params_prob; ///< Posterior probability
 
+    // No change
     std::vector< epiworld_double > drawn_prob;     ///< Drawn probabilities (runif())
     std::vector< TData > * sampled_data = nullptr;
 
@@ -162,16 +174,20 @@ private:
     LFMCMCKernelFun<TData> kernel_fun     = kernel_fun_uniform<TData>;
 
     // Misc
+    // param_names, stat_names
     std::vector< std::string > names_parameters;
     std::vector< std::string > names_statistics;
 
+    // start_time, end_time (??)
     std::chrono::time_point<std::chrono::steady_clock> time_start;
     std::chrono::time_point<std::chrono::steady_clock> time_end;
 
     // std::chrono::milliseconds
+    // elapsed_time
     std::chrono::duration<epiworld_double,std::micro> time_elapsed = 
         std::chrono::duration<epiworld_double,std::micro>::zero();
 
+    // get_elapsed_time
     inline void get_elapsed(
         std::string unit,
         epiworld_double * last_elapsed,
@@ -179,6 +195,7 @@ private:
         bool print
     ) const;
 
+    // start_chrono, end_chrono (??)
     void chrono_start();
     void chrono_end();
     
@@ -192,10 +209,10 @@ public:
         );
 
     LFMCMC() {};
-    LFMCMC(const TData & observed_data_) : observed_data(observed_data_) {};
+    LFMCMC(const TData & observed_data_) : m_observed_data(observed_data_) {};
     ~LFMCMC() {};
 
-    void set_observed_data(const TData & observed_data_) {observed_data = observed_data_;};
+    void set_observed_data(const TData & observed_data_) {m_observed_data = observed_data_;};
     void set_proposal_fun(LFMCMCProposalFun<TData> fun);
     void set_simulation_fun(LFMCMCSimFun<TData> fun);
     void set_summary_fun(LFMCMCSummaryFun<TData> fun);
@@ -220,10 +237,10 @@ public:
     ///@}
 
     // Accessing parameters of the function
-    size_t get_n_samples() const {return n_samples;};
-    size_t get_n_statistics() const {return n_statistics;};
-    size_t get_n_parameters() const {return n_parameters;};
-    epiworld_double get_epsilon() const {return epsilon;};
+    size_t get_n_samples() const {return m_n_samples;};
+    size_t get_n_stats() const {return m_n_stats;};
+    size_t get_n_params() const {return m_n_params;};
+    epiworld_double get_epsilon() const {return m_epsilon;};
 
     const std::vector< epiworld_double > & get_params_now() {return params_now;};
     const std::vector< epiworld_double > & get_params_prev() {return params_prev;};
@@ -242,6 +259,7 @@ public:
     void set_par_names(std::vector< std::string > names);
     void set_stats_names(std::vector< std::string > names);
 
+    // get_mean_params, get_mean_stats
     std::vector< epiworld_double > get_params_mean();
     std::vector< epiworld_double > get_stats_mean();
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -7,19 +7,19 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     // For each statistic or parameter in the model, we print three values: 
     // - mean, the 2.5% quantile, and the 97.5% quantile
-    std::vector< epiworld_double > summ_params(n_parameters * 3, 0.0);
-    std::vector< epiworld_double > summ_stats(n_statistics * 3, 0.0);
+    std::vector< epiworld_double > summ_params(m_n_params * 3, 0.0);
+    std::vector< epiworld_double > summ_stats(m_n_stats * 3, 0.0);
 
     // Compute the number of samples to use based on burnin rate
-    size_t n_samples_print = n_samples;
+    size_t n_samples_print = m_n_samples;
     if (burnin > 0)
     {
-        if (burnin >= n_samples)
+        if (burnin >= m_n_samples)
             throw std::length_error(
                 "The burnin is greater than or equal to the number of samples."
                 );
 
-        n_samples_print = n_samples - burnin;
+        n_samples_print = m_n_samples - burnin;
 
     }
 
@@ -28,14 +28,14 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         );
 
     // Compute parameter summary values
-    for (size_t k = 0u; k < n_parameters; ++k)
+    for (size_t k = 0u; k < m_n_params; ++k)
     {
 
         // Retrieving the relevant parameter
         std::vector< epiworld_double > par_i(n_samples_print);
-        for (size_t i = burnin; i < n_samples; ++i)
+        for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            par_i[i-burnin] = accepted_params[i * n_parameters + k];
+            par_i[i-burnin] = accepted_params[i * m_n_params + k];
             summ_params[k * 3] += par_i[i-burnin]/n_samples_dbl;
         }
 
@@ -50,14 +50,14 @@ inline void LFMCMC<TData>::print(size_t burnin) const
     }
 
     // Compute statistics summary values
-    for (size_t k = 0u; k < n_statistics; ++k)
+    for (size_t k = 0u; k < m_n_stats; ++k)
     {
 
         // Retrieving the relevant parameter
         std::vector< epiworld_double > stat_k(n_samples_print);
-        for (size_t i = burnin; i < n_samples; ++i)
+        for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            stat_k[i-burnin] = accepted_stats[i * n_statistics + k];
+            stat_k[i-burnin] = accepted_stats[i * m_n_stats + k];
             summ_stats[k * 3] += stat_k[i-burnin]/n_samples_dbl;
         }
 
@@ -73,7 +73,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
     printf_epiworld("___________________________________________\n\n");
     printf_epiworld("LIKELIHOOD-FREE MARKOV CHAIN MONTE CARLO\n\n");
 
-    printf_epiworld("N Samples : %zu\n", n_samples);
+    printf_epiworld("N Samples : %zu\n", m_n_samples);
 
     std::string abbr;
     epiworld_double elapsed;
@@ -117,7 +117,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (initial : % ") +
             charlen + std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_parameters; ++k)
+        for (size_t k = 0u; k < m_n_params; ++k)
         {
             printf_epiworld(
                 fmt_params.c_str(),
@@ -138,7 +138,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (initial : % ") + charlen +
             std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_parameters; ++k)
+        for (size_t k = 0u; k < m_n_params; ++k)
         {
             
             printf_epiworld(
@@ -189,7 +189,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (Observed: % ") + nchar_char +
             std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_statistics; ++k)
+        for (size_t k = 0u; k < m_n_stats; ++k)
         {
             printf_epiworld(
                 fmt_stats.c_str(),
@@ -211,7 +211,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
             std::string(".2f] (Observed: % ") + nchar_char +
             std::string(".2f)\n");
 
-        for (size_t k = 0u; k < n_statistics; ++k)
+        for (size_t k = 0u; k < m_n_stats; ++k)
         {
             printf_epiworld(
                 fmt_stats.c_str(),

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -125,7 +125,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_params[k * 3],
                 summ_params[k * 3 + 1u],
                 summ_params[k * 3 + 2u],
-                params_init[k]
+                m_initial_params[k]
                 );
         }
 
@@ -147,7 +147,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_params[k * 3],
                 summ_params[k * 3 + 1u],
                 summ_params[k * 3 + 2u],
-                params_init[k]
+                m_initial_params[k]
                 );
         }
 
@@ -197,7 +197,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_stats[k * 3],
                 summ_stats[k * 3 + 1u],
                 summ_stats[k * 3 + 2u],
-                observed_stats[k]
+                m_observed_stats[k]
                 );
         }
 
@@ -219,7 +219,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
                 summ_stats[k * 3],
                 summ_stats[k * 3 + 1u],
                 summ_stats[k * 3 + 2u],
-                observed_stats[k]
+                m_observed_stats[k]
                 );
         }
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -99,10 +99,10 @@ inline void LFMCMC<TData>::print(size_t burnin) const
     nchar_par_num += 5; // 1 for neg padd, 2 for decimals, 1 the decimal point, and one b/c log(<10) < 1.
     std::string charlen = std::to_string(nchar_par_num);
 
-    if (names_parameters.size() != 0u)
+    if (m_param_names.size() != 0u)
     {
         int nchar_par = 0;
-        for (auto & n : names_parameters)
+        for (auto & n : m_param_names)
         {
             int tmp_nchar = n.length();
             if (nchar_par < tmp_nchar)
@@ -121,7 +121,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         {
             printf_epiworld(
                 fmt_params.c_str(),
-                names_parameters[k].c_str(),
+                m_param_names[k].c_str(),
                 summ_params[k * 3],
                 summ_params[k * 3 + 1u],
                 summ_params[k * 3 + 2u],
@@ -171,10 +171,10 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     // Figuring out format
     std::string fmt_stats;
-    if (names_statistics.size() != 0u)
+    if (m_stat_names.size() != 0u)
     {
         int nchar_stats = 0;
-        for (auto & n : names_statistics)
+        for (auto & n : m_stat_names)
         {
             int tmp_nchar = n.length();
             if (nchar_stats < tmp_nchar)
@@ -193,7 +193,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         {
             printf_epiworld(
                 fmt_stats.c_str(),
-                names_statistics[k].c_str(),
+                m_stat_names[k].c_str(),
                 summ_stats[k * 3],
                 summ_stats[k * 3 + 1u],
                 summ_stats[k * 3 + 2u],

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat-print.hpp
@@ -35,7 +35,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > par_i(n_samples_print);
         for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            par_i[i-burnin] = accepted_params[i * m_n_params + k];
+            par_i[i-burnin] = m_accepted_params[i * m_n_params + k];
             summ_params[k * 3] += par_i[i-burnin]/n_samples_dbl;
         }
 
@@ -57,7 +57,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
         std::vector< epiworld_double > stat_k(n_samples_print);
         for (size_t i = burnin; i < m_n_samples; ++i)
         {
-            stat_k[i-burnin] = accepted_stats[i * m_n_stats + k];
+            stat_k[i-burnin] = m_accepted_stats[i * m_n_stats + k];
             summ_stats[k * 3] += stat_k[i-burnin]/n_samples_dbl;
         }
 
@@ -77,7 +77,7 @@ inline void LFMCMC<TData>::print(size_t burnin) const
 
     std::string abbr;
     epiworld_double elapsed;
-    get_elapsed("auto", &elapsed, &abbr, false);
+    get_elapsed_time("auto", &elapsed, &abbr, false);
     printf_epiworld("Elapsed t : %.2f%s\n\n", elapsed, abbr.c_str());
     
     ////////////////////////////////////////////////////////////////////////////

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -492,7 +492,7 @@ inline void LFMCMC<TData>::chrono_end() {
 }
 
 template<typename TData>
-inline void LFMCMC<TData>::set_param_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_params_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_params)
@@ -502,7 +502,7 @@ inline void LFMCMC<TData>::set_param_names(std::vector< std::string > names)
 
 }
 template<typename TData>
-inline void LFMCMC<TData>::set_stat_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_stats)

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -124,24 +124,24 @@ inline void proposal_fun_unif(
 /**
  * @brief Uses the uniform kernel with euclidean distance
  * 
- * @param stats_now Vector of current statistics based on 
- * simulated data.
- * @param stats_obs Vector of observed statistics
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
  * @param epsilon Epsilon parameter
- * @param m LFMCMC model.
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_uniform(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 ) {
 
     epiworld_double ans = 0.0;
     for (size_t p = 0u; p < m->get_n_params(); ++p)
-        ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
+        ans += std::pow(observed_stats[p] - simulated_stats[p], 2.0);
 
     return std::sqrt(ans) < epsilon ? 1.0 : 0.0;
 
@@ -153,21 +153,24 @@ inline epiworld_double kernel_fun_uniform(
  * @brief Gaussian kernel
  * 
  * @tparam TData 
- * @param epsilon 
- * @param m 
+ * @param simulated_stats Vector of statistics based on 
+ * simulated data
+ * @param observed_stats Vector of observed statistics
+ * @param epsilon Epsilon parameter
+ * @param m LFMCMC model
  * @return epiworld_double 
  */
 template<typename TData>
 inline epiworld_double kernel_fun_gaussian(
-    const std::vector< epiworld_double >& stats_now,
-    const std::vector< epiworld_double >& stats_obs,
+    const std::vector< epiworld_double >& simulated_stats,
+    const std::vector< epiworld_double >& observed_stats,
     epiworld_double epsilon,
     LFMCMC<TData>* m
 ) {
 
     epiworld_double ans = 0.0;
     for (size_t p = 0u; p < m->get_n_params(); ++p)
-        ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
+        ans += std::pow(observed_stats[p] - simulated_stats[p], 2.0);
 
     return std::exp(
         -.5 * (ans/std::pow(1 + std::pow(epsilon, 2.0)/3.0, 2.0))

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -239,17 +239,17 @@ inline void LFMCMC<TData>::run(
     drawn_prob.resize(m_n_samples);
     m_sample_acceptance.resize(m_n_samples, false);
     m_stat_samples.resize(m_n_samples * m_n_stats);
-    sampled_stats_prob.resize(m_n_samples);
+    m_sample_kernel_scores.resize(m_n_samples);
 
     m_accepted_params.resize(m_n_samples * m_n_params);
     m_accepted_stats.resize(m_n_samples * m_n_stats);
-    accepted_params_prob.resize(m_n_samples);
+    m_accepted_kernel_scores.resize(m_n_samples);
 
     TData data_i = m_simulation_fun(m_initial_params, this);
 
     std::vector< epiworld_double > proposed_stats_i;
     m_summary_fun(proposed_stats_i, data_i, this);
-    accepted_params_prob[0u] = m_kernel_fun(
+    m_accepted_kernel_scores[0u] = m_kernel_fun(
         proposed_stats_i, m_observed_stats, m_epsilon, this
         );
 
@@ -280,7 +280,7 @@ inline void LFMCMC<TData>::run(
             proposed_stats_i, m_observed_stats, m_epsilon, this
             );
 
-        sampled_stats_prob[i] = hr;
+        m_sample_kernel_scores[i] = hr;
 
         // Storing data
         for (size_t k = 0u; k < m_n_stats; ++k)
@@ -291,9 +291,9 @@ inline void LFMCMC<TData>::run(
         drawn_prob[i] = r;
 
         // Step 5: Update if likely
-        if (r < std::min(static_cast<epiworld_double>(1.0), hr / accepted_params_prob[i - 1u]))
+        if (r < std::min(static_cast<epiworld_double>(1.0), hr / m_accepted_kernel_scores[i - 1u]))
         {
-            accepted_params_prob[i] = hr;
+            m_accepted_kernel_scores[i] = hr;
             m_sample_acceptance[i]     = true;
             
             for (size_t k = 0u; k < m_n_stats; ++k)
@@ -309,7 +309,7 @@ inline void LFMCMC<TData>::run(
                 m_accepted_stats[i * m_n_stats + k] =
                     m_accepted_stats[(i - 1) * m_n_stats + k];
 
-            accepted_params_prob[i] = accepted_params_prob[i - 1u];
+            m_accepted_kernel_scores[i] = m_accepted_kernel_scores[i - 1u];
         }
             
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -179,25 +179,25 @@ inline epiworld_double kernel_fun_gaussian(
 template<typename TData>
 inline void LFMCMC<TData>::set_proposal_fun(LFMCMCProposalFun<TData> fun)
 {
-    proposal_fun = fun;
+    m_proposal_fun = fun;
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_simulation_fun(LFMCMCSimFun<TData> fun)
 {
-    simulation_fun = fun;
+    m_simulation_fun = fun;
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_summary_fun(LFMCMCSummaryFun<TData> fun)
 {
-    summary_fun = fun;
+    m_summary_fun = fun;
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_kernel_fun(LFMCMCKernelFun<TData> fun)
 {
-    kernel_fun = fun;
+    m_kernel_fun = fun;
 }
 
 
@@ -232,7 +232,7 @@ inline void LFMCMC<TData>::run(
     m_current_params  = m_initial_params;
 
     // Computing the baseline sufficient statistics
-    summary_fun(m_observed_stats, m_observed_data, this);
+    m_summary_fun(m_observed_stats, m_observed_data, this);
     m_n_stats = m_observed_stats.size();
 
     // Reserving size
@@ -245,11 +245,11 @@ inline void LFMCMC<TData>::run(
     m_accepted_stats.resize(m_n_samples * m_n_stats);
     accepted_params_prob.resize(m_n_samples);
 
-    TData data_i = simulation_fun(m_initial_params, this);
+    TData data_i = m_simulation_fun(m_initial_params, this);
 
     std::vector< epiworld_double > proposed_stats_i;
-    summary_fun(proposed_stats_i, data_i, this);
-    accepted_params_prob[0u] = kernel_fun(
+    m_summary_fun(proposed_stats_i, data_i, this);
+    accepted_params_prob[0u] = m_kernel_fun(
         proposed_stats_i, m_observed_stats, m_epsilon, this
         );
 
@@ -263,20 +263,20 @@ inline void LFMCMC<TData>::run(
     for (size_t i = 1u; i < m_n_samples; ++i)
     {
         // Step 1: Generate a proposal and store it in m_current_params
-        proposal_fun(m_current_params, m_previous_params, this);
+        m_proposal_fun(m_current_params, m_previous_params, this);
 
         // Step 2: Using m_current_params, simulate data
-        TData data_i = simulation_fun(m_current_params, this);
+        TData data_i = m_simulation_fun(m_current_params, this);
 
         // Are we storing the data?
         if (sampled_data != nullptr)
             sampled_data->operator[](i) = data_i;
 
         // Step 3: Generate the summary statistics of the data
-        summary_fun(proposed_stats_i, data_i, this);
+        m_summary_fun(proposed_stats_i, data_i, this);
 
         // Step 4: Compute the hastings ratio using the kernel function
-        epiworld_double hr = kernel_fun(
+        epiworld_double hr = m_kernel_fun(
             proposed_stats_i, m_observed_stats, m_epsilon, this
             );
 

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -327,7 +327,7 @@ inline void LFMCMC<TData>::run(
 template<typename TData>
 inline epiworld_double LFMCMC<TData>::runif()
 {
-    return runifd->operator()(*engine);
+    return runifd->operator()(*m_engine);
 }
 
 template<typename TData>
@@ -336,13 +336,13 @@ inline epiworld_double LFMCMC<TData>::runif(
     epiworld_double ub
 )
 {
-    return runifd->operator()(*engine) * (ub - lb) + lb;
+    return runifd->operator()(*m_engine) * (ub - lb) + lb;
 }
 
 template<typename TData>
 inline epiworld_double LFMCMC<TData>::rnorm()
 {
-    return rnormd->operator()(*engine);
+    return rnormd->operator()(*m_engine);
 }
 
 template<typename TData>
@@ -351,13 +351,13 @@ inline epiworld_double LFMCMC<TData>::rnorm(
     epiworld_double sd
     )
 {
-    return (rnormd->operator()(*engine)) * sd + mean;
+    return (rnormd->operator()(*m_engine)) * sd + mean;
 }
 
 template<typename TData>
 inline epiworld_double LFMCMC<TData>::rgamma()
 {
-    return rgammad->operator()(*engine);
+    return rgammad->operator()(*m_engine);
 }
 
 template<typename TData>
@@ -371,7 +371,7 @@ inline epiworld_double LFMCMC<TData>::rgamma(
 
     rgammad->param(std::gamma_distribution<>::param_type(alpha, beta));
 
-    epiworld_double ans = rgammad->operator()(*engine);
+    epiworld_double ans = rgammad->operator()(*m_engine);
 
     rgammad->param(old_param);
 
@@ -382,14 +382,14 @@ inline epiworld_double LFMCMC<TData>::rgamma(
 template<typename TData>
 inline void LFMCMC<TData>::seed(epiworld_fast_uint s) {
 
-    this->engine->seed(s);
+    this->m_engine->seed(s);
 
 }
 
 template<typename TData>
 inline void LFMCMC<TData>::set_rand_engine(std::shared_ptr< std::mt19937 > & eng)
 {
-    engine = eng;
+    m_engine = eng;
 }
 
 template<typename TData>
@@ -401,7 +401,7 @@ inline void LFMCMC<TData>::set_rand_gamma(epiworld_double alpha, epiworld_double
 template<typename TData>
 inline std::shared_ptr< std::mt19937 > & LFMCMC<TData>::get_rand_endgine()
 {
-    return engine;
+    return m_engine;
 }
 
 // Step 1: Simulate data

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -225,8 +225,8 @@ inline void LFMCMC<TData>::run(
     m_current_params.resize(m_n_params);
     m_previous_params.resize(m_n_params);
 
-    if (sampled_data != nullptr)
-        sampled_data->resize(m_n_samples);
+    if (m_simulated_data != nullptr)
+        m_simulated_data->resize(m_n_samples);
 
     m_previous_params = m_initial_params;
     m_current_params  = m_initial_params;
@@ -236,9 +236,9 @@ inline void LFMCMC<TData>::run(
     m_n_stats = m_observed_stats.size();
 
     // Reserving size
-    drawn_prob.resize(m_n_samples);
+    m_sample_drawn_prob.resize(m_n_samples);
     m_sample_acceptance.resize(m_n_samples, false);
-    m_stat_samples.resize(m_n_samples * m_n_stats);
+    m_sample_stats.resize(m_n_samples * m_n_stats);
     m_sample_kernel_scores.resize(m_n_samples);
 
     m_accepted_params.resize(m_n_samples * m_n_params);
@@ -255,7 +255,7 @@ inline void LFMCMC<TData>::run(
 
     // Recording statistics
     for (size_t i = 0u; i < m_n_stats; ++i)
-        m_stat_samples[i] = proposed_stats_i[i];
+        m_sample_stats[i] = proposed_stats_i[i];
 
     for (size_t k = 0u; k < m_n_params; ++k)
         m_accepted_params[k] = m_initial_params[k];
@@ -269,8 +269,8 @@ inline void LFMCMC<TData>::run(
         TData data_i = m_simulation_fun(m_current_params, this);
 
         // Are we storing the data?
-        if (sampled_data != nullptr)
-            sampled_data->operator[](i) = data_i;
+        if (m_simulated_data != nullptr)
+            m_simulated_data->operator[](i) = data_i;
 
         // Step 3: Generate the summary statistics of the data
         m_summary_fun(proposed_stats_i, data_i, this);
@@ -284,11 +284,11 @@ inline void LFMCMC<TData>::run(
 
         // Storing data
         for (size_t k = 0u; k < m_n_stats; ++k)
-            m_stat_samples[i * m_n_stats + k] = proposed_stats_i[k];
+            m_sample_stats[i * m_n_stats + k] = proposed_stats_i[k];
         
         // Running Hastings ratio
         epiworld_double r = runif();
-        drawn_prob[i] = r;
+        m_sample_drawn_prob[i] = r;
 
         // Step 5: Update if likely
         if (r < std::min(static_cast<epiworld_double>(1.0), hr / m_accepted_kernel_scores[i - 1u]))

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -17,7 +17,7 @@ inline void proposal_fun_normal(
     LFMCMC<TData>* m
 ) {
 
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         params_now[p] = params_prev[p] + m->rnorm();
 
     return;
@@ -50,7 +50,7 @@ inline LFMCMCProposalFun<TData> make_proposal_norm_reflective(
         ) {
 
         // Making the proposal
-        for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+        for (size_t p = 0u; p < m->get_n_params(); ++p)
             params_now[p] = params_prev[p] + m->rnorm() * scale;
 
         // Checking boundaries
@@ -115,7 +115,7 @@ inline void proposal_fun_unif(
     LFMCMC<TData>* m
 ) {
 
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         params_now[p] = (params_prev[p] + m->runif(-1.0, 1.0));
 
     return;
@@ -140,7 +140,7 @@ inline epiworld_double kernel_fun_uniform(
 ) {
 
     epiworld_double ans = 0.0;
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
 
     return std::sqrt(ans) < epsilon ? 1.0 : 0.0;
@@ -166,7 +166,7 @@ inline epiworld_double kernel_fun_gaussian(
 ) {
 
     epiworld_double ans = 0.0;
-    for (size_t p = 0u; p < m->get_n_parameters(); ++p)
+    for (size_t p = 0u; p < m->get_n_params(); ++p)
         ans += std::pow(stats_obs[p] - stats_now[p], 2.0);
 
     return std::exp(
@@ -214,53 +214,53 @@ inline void LFMCMC<TData>::run(
     chrono_start();
 
     // Setting the baseline parameters of the model
-    n_samples    = n_samples_;
-    epsilon      = epsilon_;
+    m_n_samples    = n_samples_;
+    m_epsilon      = epsilon_;
     params_init  = params_init_;
-    n_parameters = params_init_.size();
+    m_n_params = params_init_.size();
 
     if (seed >= 0)
         this->seed(seed);
 
-    params_now.resize(n_parameters);
-    params_prev.resize(n_parameters);
+    params_now.resize(m_n_params);
+    params_prev.resize(m_n_params);
 
     if (sampled_data != nullptr)
-        sampled_data->resize(n_samples);
+        sampled_data->resize(m_n_samples);
 
     params_prev = params_init;
     params_now  = params_init;
 
     // Computing the baseline sufficient statistics
-    summary_fun(observed_stats, observed_data, this);
-    n_statistics = observed_stats.size();
+    summary_fun(observed_stats, m_observed_data, this);
+    m_n_stats = observed_stats.size();
 
     // Reserving size
-    drawn_prob.resize(n_samples);
-    sampled_accepted.resize(n_samples, false);
-    sampled_stats.resize(n_samples * n_statistics);
-    sampled_stats_prob.resize(n_samples);
+    drawn_prob.resize(m_n_samples);
+    sampled_accepted.resize(m_n_samples, false);
+    sampled_stats.resize(m_n_samples * m_n_stats);
+    sampled_stats_prob.resize(m_n_samples);
 
-    accepted_params.resize(n_samples * n_parameters);
-    accepted_stats.resize(n_samples * n_statistics);
-    accepted_params_prob.resize(n_samples);
+    accepted_params.resize(m_n_samples * m_n_params);
+    accepted_stats.resize(m_n_samples * m_n_stats);
+    accepted_params_prob.resize(m_n_samples);
 
     TData data_i = simulation_fun(params_init, this);
 
     std::vector< epiworld_double > proposed_stats_i;
     summary_fun(proposed_stats_i, data_i, this);
     accepted_params_prob[0u] = kernel_fun(
-        proposed_stats_i, observed_stats, epsilon, this
+        proposed_stats_i, observed_stats, m_epsilon, this
         );
 
     // Recording statistics
-    for (size_t i = 0u; i < n_statistics; ++i)
+    for (size_t i = 0u; i < m_n_stats; ++i)
         sampled_stats[i] = proposed_stats_i[i];
 
-    for (size_t k = 0u; k < n_parameters; ++k)
+    for (size_t k = 0u; k < m_n_params; ++k)
         accepted_params[k] = params_init[k];
    
-    for (size_t i = 1u; i < n_samples; ++i)
+    for (size_t i = 1u; i < m_n_samples; ++i)
     {
         // Step 1: Generate a proposal and store it in params_now
         proposal_fun(params_now, params_prev, this);
@@ -277,14 +277,14 @@ inline void LFMCMC<TData>::run(
 
         // Step 4: Compute the hastings ratio using the kernel function
         epiworld_double hr = kernel_fun(
-            proposed_stats_i, observed_stats, epsilon, this
+            proposed_stats_i, observed_stats, m_epsilon, this
             );
 
         sampled_stats_prob[i] = hr;
 
         // Storing data
-        for (size_t k = 0u; k < n_statistics; ++k)
-            sampled_stats[i * n_statistics + k] = proposed_stats_i[k];
+        for (size_t k = 0u; k < m_n_stats; ++k)
+            sampled_stats[i * m_n_stats + k] = proposed_stats_i[k];
         
         // Running Hastings ratio
         epiworld_double r = runif();
@@ -296,8 +296,8 @@ inline void LFMCMC<TData>::run(
             accepted_params_prob[i] = hr;
             sampled_accepted[i]     = true;
             
-            for (size_t k = 0u; k < n_statistics; ++k)
-                accepted_stats[i * n_statistics + k] =
+            for (size_t k = 0u; k < m_n_stats; ++k)
+                accepted_stats[i * m_n_stats + k] =
                     proposed_stats_i[k];
 
             params_prev = params_now;
@@ -305,16 +305,16 @@ inline void LFMCMC<TData>::run(
         } else
         {
 
-            for (size_t k = 0u; k < n_statistics; ++k)
-                accepted_stats[i * n_statistics + k] =
-                    accepted_stats[(i - 1) * n_statistics + k];
+            for (size_t k = 0u; k < m_n_stats; ++k)
+                accepted_stats[i * m_n_stats + k] =
+                    accepted_stats[(i - 1) * m_n_stats + k];
 
             accepted_params_prob[i] = accepted_params_prob[i - 1u];
         }
             
 
-        for (size_t k = 0u; k < n_parameters; ++k)
-            accepted_params[i * n_parameters + k] = params_prev[k];
+        for (size_t k = 0u; k < m_n_params; ++k)
+            accepted_params[i * m_n_params + k] = params_prev[k];
 
     }
 
@@ -492,7 +492,7 @@ template<typename TData>
 inline void LFMCMC<TData>::set_par_names(std::vector< std::string > names)
 {
 
-    if (names.size() != n_parameters)
+    if (names.size() != m_n_params)
         throw std::length_error("The number of names to add differs from the number of parameters in the model.");
 
     names_parameters = names;
@@ -502,7 +502,7 @@ template<typename TData>
 inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
 {
 
-    if (names.size() != n_statistics)
+    if (names.size() != m_n_stats)
         throw std::length_error("The number of names to add differs from the number of statistics in the model.");
 
     names_statistics = names;
@@ -512,13 +512,13 @@ inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
 template<typename TData>
 inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
 {
-    std::vector< epiworld_double > res(this->n_parameters, 0.0);
+    std::vector< epiworld_double > res(this->m_n_params, 0.0);
     
-    for (size_t k = 0u; k < n_parameters; ++k)
+    for (size_t k = 0u; k < m_n_params; ++k)
     {
-        for (size_t i = 0u; i < n_samples; ++i)
-            res[k] += (this->accepted_params[k + n_parameters * i])/
-                static_cast< epiworld_double >(n_samples);
+        for (size_t i = 0u; i < m_n_samples; ++i)
+            res[k] += (this->accepted_params[k + m_n_params * i])/
+                static_cast< epiworld_double >(m_n_samples);
     }
 
     return res;
@@ -528,13 +528,13 @@ inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
 template<typename TData>
 inline std::vector< epiworld_double > LFMCMC<TData>::get_stats_mean()
 {
-    std::vector< epiworld_double > res(this->n_statistics, 0.0);
+    std::vector< epiworld_double > res(this->m_n_stats, 0.0);
     
-    for (size_t k = 0u; k < n_statistics; ++k)
+    for (size_t k = 0u; k < m_n_stats; ++k)
     {
-        for (size_t i = 0u; i < n_samples; ++i)
-            res[k] += (this->accepted_stats[k + n_statistics * i])/
-                static_cast< epiworld_double >(n_samples);
+        for (size_t i = 0u; i < m_n_samples; ++i)
+            res[k] += (this->accepted_stats[k + m_n_stats * i])/
+                static_cast< epiworld_double >(m_n_samples);
     }
 
     return res;

--- a/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
+++ b/include/epiworld/math/lfmcmc/lfmcmc-meat.hpp
@@ -489,28 +489,28 @@ inline void LFMCMC<TData>::chrono_end() {
 }
 
 template<typename TData>
-inline void LFMCMC<TData>::set_par_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_param_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_params)
         throw std::length_error("The number of names to add differs from the number of parameters in the model.");
 
-    names_parameters = names;
+    m_param_names = names;
 
 }
 template<typename TData>
-inline void LFMCMC<TData>::set_stats_names(std::vector< std::string > names)
+inline void LFMCMC<TData>::set_stat_names(std::vector< std::string > names)
 {
 
     if (names.size() != m_n_stats)
         throw std::length_error("The number of names to add differs from the number of statistics in the model.");
 
-    names_statistics = names;
+    m_stat_names = names;
 
 }
 
 template<typename TData>
-inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
+inline std::vector< epiworld_double > LFMCMC<TData>::get_mean_params()
 {
     std::vector< epiworld_double > res(this->m_n_params, 0.0);
     
@@ -526,7 +526,7 @@ inline std::vector< epiworld_double > LFMCMC<TData>::get_params_mean()
 }
 
 template<typename TData>
-inline std::vector< epiworld_double > LFMCMC<TData>::get_stats_mean()
+inline std::vector< epiworld_double > LFMCMC<TData>::get_mean_stats()
 {
     std::vector< epiworld_double > res(this->m_n_stats, 0.0);
     

--- a/tests/00-lfmcmc.cpp
+++ b/tests/00-lfmcmc.cpp
@@ -66,8 +66,8 @@ EPIWORLD_TEST_CASE("LFMCMC", "[Basic example]") {
     model.print();
     model.print(50000);
 
-    auto params_means = model.get_params_mean();
-    auto stats_means  = model.get_stats_mean();
+    auto params_means = model.get_mean_params();
+    auto stats_means  = model.get_mean_stats();
 
     #ifdef CATCH_CONFIG_MAIN
     std::vector<epiworld_double> expected = {5.0, 1.5};

--- a/tests/00-lfmcmc.cpp
+++ b/tests/00-lfmcmc.cpp
@@ -35,7 +35,7 @@ void summary_fun(vec_double & res, const vec_double & p, LFMCMC<vec_double> * m)
 
     *sd = std::sqrt(*sd);
 
-    auto params = m->get_params_now();
+    auto params = m->get_current_params();
 
     // printf("{mu, sigma} = {% 4.2f, % 4.2f}; ", params[0u], params[1u]);
     // printf("{mean, sd} =  {% 4.2f, % 4.2f}\n", *mean, *sd);


### PR DESCRIPTION
This pull request introduces many variable and method name changes to the LFMCMC class. Generally, these changes include:

- Adding the `m_` prefix to member variables to improve understanding of variable usage
- Renaming variables to more descriptive names
- Renaming getters and setters to reflect member variable name
- Cleaning up comments and organization of variables and methods