### PR TITLE
Adds test for bug about edgelist in run multiple (and fixes)

### DIFF
--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -24,7 +24,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 8
-#define EPIWORLD_VERSION_PATCH 2
+#define EPIWORLD_VERSION_PATCH 3
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -15242,8 +15242,8 @@ inline Agent<TSeq> & Agent<TSeq>::operator=(
 
     if (other_agent.n_neighbors > 0u)
     {
-        neighbors = new std::vector< size_t >(other_agent.n_neighbors);
-        neighbors_locations = new std::vector< size_t >(other_agent.n_neighbors);
+        neighbors = new std::vector< size_t >(*other_agent.neighbors);
+        neighbors_locations = new std::vector< size_t >(*other_agent.neighbors_locations);
     }
     
     entities = other_agent.entities;

--- a/include/epiworld/agent-meat.hpp
+++ b/include/epiworld/agent-meat.hpp
@@ -110,8 +110,8 @@ inline Agent<TSeq> & Agent<TSeq>::operator=(
 
     if (other_agent.n_neighbors > 0u)
     {
-        neighbors = new std::vector< size_t >(other_agent.n_neighbors);
-        neighbors_locations = new std::vector< size_t >(other_agent.n_neighbors);
+        neighbors = new std::vector< size_t >(*other_agent.neighbors);
+        neighbors_locations = new std::vector< size_t >(*other_agent.neighbors_locations);
     }
     
     entities = other_agent.entities;

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -24,7 +24,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 8
-#define EPIWORLD_VERSION_PATCH 2
+#define EPIWORLD_VERSION_PATCH 3
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/tests/15-edgelist-after-run-multiple.cpp
+++ b/tests/15-edgelist-after-run-multiple.cpp
@@ -1,0 +1,36 @@
+#ifndef CATCH_CONFIG_MAIN
+// #define EPI_DEBUG
+#endif
+
+#define EPI_DEBUG_NO_THREAD_ID
+#include "tests.hpp"
+
+using namespace epiworld;
+
+EPIWORLD_TEST_CASE("Edgelist is preserved in run multiple", "[Edgelist]") {
+
+    // Queuing doesn't matter and get results that are meaningful
+    epimodels::ModelSIR<> model_0(
+        "a virus", 0.01, .9, .3
+        );
+
+    model_0.seed(1231);
+    model_0.agents_smallworld(500, 5, false, 0.01);
+    model_0.verbose_off();
+
+    std::vector< int > source0a, target0a;
+    std::vector< int > source0b, target0b;
+    model_0.write_edgelist(source0a, target0a);
+    model_0.run_multiple(100, 100, 1231, nullptr, true, true, 1);
+    model_0.write_edgelist(source0b, target0b);
+
+    #ifdef CATCH_CONFIG_MAIN
+    REQUIRE( source0a == source0b );
+    REQUIRE( target0a == target0b );
+    #endif
+
+    #ifndef CATCH_CONFIG_MAIN
+    return 0;
+    #endif
+
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -27,3 +27,4 @@
 #include "14a-measles.cpp"
 #include "14b-measles.cpp"
 #include "14c-measles.cpp"
+#include "15-edgelist-after-run-multiple.cpp"


### PR DESCRIPTION
This pull request introduces improvements to memory handling in the `Agent` class, along with the addition of a new test to ensure the integrity of edge lists after running multiple simulations. The most important changes include fixing a bug in the copy assignment operator of the `Agent` class and adding a new test case to validate edge list preservation.

### Memory handling improvements:

* `epiworld.hpp` and `include/epiworld/agent-meat.hpp`: Fixed a bug in the `Agent<TSeq>::operator=` method by ensuring that `neighbors` and `neighbors_locations` are deep-copied using the dereferenced pointers from the source agent. This prevents potential memory corruption issues when copying agents. [[1]](diffhunk://#diff-3bdaf2103de7e4092beaf2f4c5e966635c155d3bd36ca531765a5337db0bd5faL15245-R15246) [[2]](diffhunk://#diff-000c70ccae61afe05465f702d5e79e5bd9bdd787528f6d9cda009263513b415bL113-R114)

### Testing enhancements:

* [`tests/15-edgelist-after-run-multiple.cpp`](diffhunk://#diff-0fda380beb5301de07f33f2014a10eddf428d89bc939aedd28fd310f5092c7feR1-R36): Added a new test case to verify that the edge list remains consistent before and after running multiple simulations. This ensures that the edge list is preserved correctly across runs.
* [`tests/main.cpp`](diffhunk://#diff-94b2761df4b7e62398c5417dc22ef505f2fdeaee50bca8c7949e36637e6c4353R30): Updated the test suite to include the new edge list preservation test.